### PR TITLE
Fixing parameter div for safari

### DIFF
--- a/proxyui/src/main/webapp/WEB-INF/views/history.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/history.jsp
@@ -161,9 +161,9 @@
                     <h3>
                         <span class="label label-default">Parameters</span>
                     </h3>
-                    <textarea class="form-control" rows="1" style="width: 100%; float:left"
+                    <textarea class="form-control" rows="1" style="width: 100%; overflow-y: scroll; float:left"
                         id="requestParameters"></textarea>
-                    <textarea class="form-control" rows="1" style="width: 100%; float: left; display: none"
+                    <textarea class="form-control" rows="1" style="width: 100%; float: left; overflow-y: scroll; display: none"
                         id="originalRequestParameters"></textarea>
                     <div class="form-control" style="width: 100%; float: left; display: none; overflow-y: scroll; resize:both"
                         id="originalRequestParametersChanged"></div>


### PR DESCRIPTION
When the parameters box was resized on safari, it was disappearing, possibly due to overflow being hidden.