### PR TITLE
UI Changes: grids can be resized horizontally; other small changes

### DIFF
--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -954,8 +954,7 @@
                 });
                 grid.jqGrid('filterToolbar', { defaultSearch: 'cn', stringResult: true });
 
-                /* ALLOWS THE PATH PRIORITY TO BE SET INSIDE OF THE PATH TABLE, INSTEAD OF ON A SEPARATE PAGE */
-                grid.jqGrid('sortableRows', {
+                var options = {
                     update: function(event, ui) {
                         var pathOrder = "";
                         var paths = grid.jqGrid('getRowData');
@@ -977,8 +976,27 @@
                         });
                     },
                     placeholder: "ui-state-highlight"
-                });
+                };
 
+                var curr = false;
+                grid.jqGrid('navButtonAdd', '#packagePager', {
+                    caption: "Reorder",
+                    buttonicon: "ui-icon-carat-2-n-s",
+                    title: "Toggle Reorder Path Priority",
+                    id: "reorder_packages",
+                    onClickButton: function() {
+                        curr = !curr;
+
+                        if( curr ) {
+                            /* ALLOWS THE PATH PRIORITY TO BE SET INSIDE OF THE PATH TABLE, INSTEAD OF ON A SEPARATE PAGE */
+                            grid.jqGrid('sortableRows', options);
+                            $("#reorder_packages").addClass("ui-state-highlight");
+                        } else {
+                            $("#packages tbody").sortable('destroy');
+                            $("#reorder_packages").removeClass("ui-state-highlight");
+                        }
+                    }
+                });
 
                 $("#tabs").tabs();
                 $("#tabs").css("overflow", "auto");

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -85,7 +85,7 @@
             var editServerGroupId = 0;
 
             function navigateHelp() {
-                window.open("https://github.com/groupon/odo/wiki","help");
+                window.open("https://github.com/groupon/odo#readme","help");
             }
 
             function navigateEditGroups() {0
@@ -1824,7 +1824,7 @@
                     <!-- TO FIND HELP -->
                     <div class="form-group navbar-form navbar-left">
                         <button id="helpButton" class="btn btn-info" onclick="navigateHelp()"
-                                target="_blank" data-toggle="tooltip" data-placement="bottom" title="Click here to read the wiki.">Need Help?</button>
+                                target="_blank" data-toggle="tooltip" data-placement="bottom" title="Click here to read the readme.">Need Help?</button>
                     </div>
 
                     <ul id="clientInfo" class="nav navbar-nav navbar-right">

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -93,7 +93,7 @@
             }
 
             function navigateRequestHistory() {
-                window.open('<c:url value='/history/${profile_id}'/>?clientUUID=${clientUUID}', "request-history");
+                window.open('<c:url value='/history/${profile_id}'/>?clientUUID=${clientUUID}', '<c:url value='/history/${profile_id}'/>?clientUUID=${clientUUID}');
             }
 
             function navigateProfiles() {

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -512,6 +512,7 @@
                 // turn on tooltips
                 $("#resetProfileButton").tooltip();
                 $("#helpButton").tooltip();
+                $("#gs_pathName").tooltip({content:"Use this box to filter the path names."});
                 $.ajax({
                     type : "GET",
                     url : '<c:url value="/api/profile/${profile_id}/clients/"/>' + $.cookie("UUID"),
@@ -568,14 +569,19 @@
                         name : 'srcUrl',
                         index : 'srcUrl',
                         width : 160,
-                        editable : true
+                        editable : true,
+                        edittype:"text",
+                        editrules:{required:true, custom:true, custom_func: srcValidation},
+                        formoptions:{label: "Source Hostname/IP (*)"}
                     }, {
                         name : 'destUrl',
                         index : 'destUrl',
                         width : 160,
                         editable : true,
                         formatter : destinationHostFormatter,
-                        unformat : destinationHostUnFormatter
+                        unformat : destinationHostUnFormatter,
+                        editoptions:{title:"default: forwards to source"},
+                        editrules:{required:true, custom:true, custom_func: destValidation},
                     }, {
                         name : 'hostHeader',
                         index : 'hostHeader',
@@ -634,7 +640,9 @@
                     edit : false,
                     add : true,
                     del : true,
-                    search: false
+                    search: false,
+                    addtext:"Add an API server",
+                    deltext:"Delete an API server"
                 },
                 {},
                 {
@@ -642,7 +650,41 @@
                     reloadAfterSubmit: false,
                     closeAfterAdd: true,
                     closeAfterEdit:true,
+                    topinfo:"Fields marked with a (*) are required.",
                     width: 400,
+                    beforeShowForm: function(formid) {
+                        /* CREATE PLACEHOLDERS FOR ADD FORM. */
+                        /* INITIALLY, GRAY */
+                        $("#srcUrl").val("ex. groupon.com");
+                        $("#srcUrl").css("color", "gray");
+
+                        $("#destUrl").val("ex. 123.45.67.890");
+                        $("#destUrl").css("color", "gray");
+                    },
+                    afterShowForm: function(formid) {
+                        /* SHIFT INITIAL FOCUS TO CANCEL TO MINIMIZE ACCIDENTAL CREATION OF
+                            INCORRECT HOSTNAME.
+                         */
+                        $("#cData").focus();
+
+                        var src = true;
+                        $("#srcUrl").focus(function(){
+                            if( src ) {
+                                $("#srcUrl").val("");
+                                $("#srcUrl").css("color", "black");
+                                src = false;
+                            }
+                        });
+
+                        var dest = true;
+                        $("#destUrl").focus(function(){
+                            if( dest ) {
+                                $("#destUrl").val("");
+                                $("#destUrl").css("color", "black");
+                                dest = false;
+                            }
+                        });
+                    },
                     afterSubmit: function () {
                         reloadGrid("#serverlist");
                         return [true];
@@ -751,9 +793,12 @@
                             index: 'pathName',
                             width: "330",
                             editrules: {
-                                required: true
+                                required: true,
+                                custom: true,
+                                custom_func: pathNameValidation
                             },
-                            editable: true
+                            editable: true,
+                            formoptions:{label: "Path name (*)"}
                         },
                         {
                             name: 'path',
@@ -761,9 +806,12 @@
                             hidden: true,
                             editrules: {
                                 required: true,
-                                edithidden: true
+                                edithidden: true,
+                                custom: true,
+                                custom_func: pathValidation
                             },
                             editable: true,
+                            formoptions:{label: "Path (*)"}
                         },
                         { name: 'requestType',
                           index: 'requestType',
@@ -819,6 +867,7 @@
                     },
                     pager: '#packagePager',
                     pgbuttons: false,
+                    pgtext: null,
                     rowList : [],
                     rowNum: 10000,
                     sortname : 'id',
@@ -827,7 +876,14 @@
                     viewrecords: true,
                 });
                 grid.jqGrid('navGrid', '#packagePager',
-                    { add: true, edit: false, del: true, search: false },
+                    {
+                        add: true,
+                        edit: false,
+                        del: true,
+                        search: false,
+                        addtext: "Add a path",
+                        deltext: "Delete a path"
+                    },
                     {},
                     {
                         // Add path
@@ -836,6 +892,7 @@
                         width: 460,
                         closeAfterAdd: true,
                         closeAfterEdit:true,
+                        topinfo:"Fields marked with a (*) are required.",
                         errorTextFormat: function (data) {
                             console.log(data);
                             return data.responseText;
@@ -847,7 +904,39 @@
                         },
                         beforeShowForm: function(data) {
                             $("#statusNotificationDiv").fadeOut();
-                        }
+
+                            /* CREATE PLACEHOLDERS FOR ADD FORM. */
+                            /* INITIALLY, GRAY */
+                            $("#pathName").val("ex. Collections");
+                            $("#pathName").css("color", "gray");
+
+                            $("#path").val("ex. /http500, /(a|b)");
+                            $("#path").css("color", "gray");
+                        },
+                        afterShowForm: function(formid) {
+                            /* SHIFT INITIAL FOCUS TO CANCEL TO MINIMIZE ACCIDENTAL CREATION OF
+                             INCORRECT HOSTNAME.
+                             */
+                            $("#cData").focus();
+
+                            var name = true;
+                            $("#pathName").focus(function(){
+                                if( name ) {
+                                    $("#pathName").val("");
+                                    $("#pathName").css("color", "black");
+                                    name = false;
+                                }
+                            });
+
+                            var path = true;
+                            $("#path").focus(function(){
+                                if( path ) {
+                                    $("#path").val("");
+                                    $("#path").css("color", "black");
+                                    path = false;
+                                }
+                            });
+                        },
                     },
                     {
                         // Delete path
@@ -866,7 +955,7 @@
                 $("#sel1").select2();
 
                 var currentHTML = $("#gview_serverlist > .ui-jqgrid-titlebar > span").html();
-                var dropDown = "&nbsp;&nbsp;&nbsp;<input id='serverGroupSelection' style='width:360px%'></input>&nbsp;&nbsp;<button id='editServerGroups' type='button' class='btn btn-xs' onClick='toggleServerGroupEdit()'><span class='glyphicon glyphicon-cog'></span></button>";
+                var dropDown = "&nbsp;&nbsp;&nbsp;<input id='serverGroupSelection' style='width:300px%'></input>&nbsp;&nbsp;<button id='editServerGroups' type='button' class='btn btn-xs' onClick='toggleServerGroupEdit()'>Server Grps ></button>";
                 $("#gview_serverlist > .ui-jqgrid-titlebar > span").html(currentHTML + dropDown);
 
                 $("#serverGroupSelection").select2({
@@ -941,6 +1030,37 @@
             });
             loadPath(currentPathId);
 
+            function srcValidation(val, colname) {
+                if( val.trim() === "ex. groupon.com" ) {
+                    return [false, "Please replace the example source hostname with a valid hostname."]
+                } else {
+                    return [true, ""];
+                }
+            }
+
+            function destValidation(val, colname) {
+                if( val.trim() === "ex. 123.45.67.890" ) {
+                    return [false, "Please replace the example destination hostname with a valid hostname."]
+                } else {
+                    return [true, ""];
+                }
+            }
+
+            function pathNameValidation(val, colname) {
+                if( val.trim() === "ex. Collections" ) {
+                    return [false, "Please replace the example path name with a valid name."]
+                } else {
+                    return [true, ""];
+                }
+            }
+
+            function pathValidation(val, colname) {
+                if( val.trim() === "ex. /http, /(a|b)" ) {
+                    return [false, "Please replace the example destination hostname with a valid hostname."]
+                } else {
+                    return [true, ""];
+                }
+            }
 
             function setActiveServerGroup(groupId) {
                 $.ajax({
@@ -1624,6 +1744,7 @@
             <div class="container-fluid">
                 <div class="collapse navbar-collapse">
                     <ul id="status2"  class="nav navbar-nav navbar-left">
+                        <li class="navbar-brand">Odo</li>
                         <li><a href="#" onClick="navigateProfiles()">Profiles</a> </li>
                         <li><a href="#" onClick="navigateRequestHistory()">Request History</a></li>
                         <li id="navbarPathPriority"><a href="#" onClick="navigatePathPriority()">Path Priority</a></li>
@@ -1637,7 +1758,7 @@
                     </div>
                     <!-- TO FIND HELP -->
                     <div class="form-group navbar-form navbar-left">
-                        <button is="helpButton" class="btn btn-info" onclick="navigateHelp()"
+                        <button id="helpButton" class="btn btn-info" onclick="navigateHelp()"
                                 target="_blank" data-toggle="tooltip" data-placement="bottom" title="Click here to read the wiki.">Need Help?</button>
                     </div>
 

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -108,14 +108,6 @@
             function navigatePathPriority() {
                 window.location = '<c:url value = '/pathorder/${profile_id}'/>';
             }
-            
-            function navigateRequestHistory() {
-                window.open('<c:url value='/history/${profile_id}'/>?clientUUID=${clientUUID}', "_blank");
-            }
-
-            function navigateProfiles() {
-                window.location = '<c:url value='/profiles'/>';
-            }
 
             function updateStatus() {
                 var status = $("#status");
@@ -655,10 +647,10 @@
                     beforeShowForm: function(formid) {
                         /* CREATE PLACEHOLDERS FOR ADD FORM. */
                         /* INITIALLY, GRAY */
-                        $("#srcUrl").val("ex. groupon.com");
+                        $("#srcUrl").val(getExampleText("src"));
                         $("#srcUrl").css("color", "gray");
 
-                        $("#destUrl").val("ex. 123.45.67.890");
+                        $("#destUrl").val(getExampleText("dest"));
                         $("#destUrl").css("color", "gray");
                     },
                     afterShowForm: function(formid) {
@@ -899,7 +891,7 @@
                         },
                         afterComplete: function(data) {
                             reloadGrid("#packages");
-                            $("#statusNotificationText").html("Path added.  Don't forget to add a hostname <b>above</b> and<br>adjust <a href=\"#\" onClick=\"navigatePathPriority()\" style=\"color: blue\">Path Priorities</a>!");
+                            $("#statusNotificationText").html("Path added.  Don't forget to add a hostname <b>above</b> and<br>adjust path priorities by <b>dragging and dropping</b> rows<br>in the path table!");
                             $("#statusNotificationDiv").fadeIn();
                         },
                         beforeShowForm: function(data) {
@@ -907,10 +899,10 @@
 
                             /* CREATE PLACEHOLDERS FOR ADD FORM. */
                             /* INITIALLY, GRAY */
-                            $("#pathName").val("ex. Collections");
+                            $("#pathName").val(getExampleText("pathName"));
                             $("#pathName").css("color", "gray");
 
-                            $("#path").val("ex. /http500, /(a|b)");
+                            $("#path").val(getExampleText("path"));
                             $("#path").css("color", "gray");
                         },
                         afterShowForm: function(formid) {
@@ -948,6 +940,33 @@
                     {});
                 grid.jqGrid('gridResize');
                 grid.jqGrid('filterToolbar', { defaultSearch: 'cn', stringResult: true });
+
+                /* ALLOWS THE PATH PRIORITY TO BE SET INSIDE OF THE PATH TABLE, INSTEAD OF ON A SEPARATE PAGE */
+                grid.jqGrid('sortableRows', {
+                    update: function(event, ui) {
+                        var pathOrder = "";
+                        var paths = grid.jqGrid('getRowData');
+                        for( var i = 0; i < paths.length; i++ ) {
+                            if( i === paths.length - 1 ) {
+                                pathOrder += paths[i]["pathId"];
+                            } else {
+                                pathOrder += paths[i]["pathId"] + ",";
+                            }
+                        }
+                        $.ajax({
+                            type: "POST",
+                            url: '<c:url value="/pathorder/"/>${profile_id}',
+                            data: ({pathOrder : pathOrder}),
+                            success: function() {
+                                $('#info').html('Path Order Updated');
+                                $('#info').fadeOut(1).delay(50).fadeIn(150);
+                            }
+                        });
+                    },
+                    placeholder: "ui-state-highlight"
+                });
+
+
                 $("#tabs").tabs();
                 $("#tabs").css("overflow", "auto");
                 $("#tabs").css("min-height", "500px");
@@ -1030,8 +1049,23 @@
             });
             loadPath(currentPathId);
 
+            function getExampleText(item) {
+                switch(item) {
+                    case "src":
+                        return "ex. groupon.com";
+                    case "dest":
+                        return "ex. 123.45.67.890";
+                    case "pathName":
+                        return "ex. Collections";
+                    case "path":
+                        return "ex. /http500, /(a|b)"
+                    default:
+                        return null;
+                }
+            }
+
             function srcValidation(val, colname) {
-                if( val.trim() === "ex. groupon.com" ) {
+                if( val.trim() === getExampleText("src") ) {
                     return [false, "Please replace the example source hostname with a valid hostname."]
                 } else {
                     return [true, ""];
@@ -1039,7 +1073,7 @@
             }
 
             function destValidation(val, colname) {
-                if( val.trim() === "ex. 123.45.67.890" ) {
+                if( val.trim() === getExampleText("dest") ) {
                     return [false, "Please replace the example destination hostname with a valid hostname."]
                 } else {
                     return [true, ""];
@@ -1047,7 +1081,7 @@
             }
 
             function pathNameValidation(val, colname) {
-                if( val.trim() === "ex. Collections" ) {
+                if( val.trim() === getExampleText("pathName") ) {
                     return [false, "Please replace the example path name with a valid name."]
                 } else {
                     return [true, ""];
@@ -1055,7 +1089,7 @@
             }
 
             function pathValidation(val, colname) {
-                if( val.trim() === "ex. /http, /(a|b)" ) {
+                if( val.trim() === getExampleText("path") ) {
                     return [false, "Please replace the example destination hostname with a valid hostname."]
                 } else {
                     return [true, ""];
@@ -1747,7 +1781,7 @@
                         <li class="navbar-brand">Odo</li>
                         <li><a href="#" onClick="navigateProfiles()">Profiles</a> </li>
                         <li><a href="#" onClick="navigateRequestHistory()">Request History</a></li>
-                        <li id="navbarPathPriority"><a href="#" onClick="navigatePathPriority()">Path Priority</a></li>
+                        <!--<li id="navbarPathPriority"><a href="#" onClick="navigatePathPriority()">Path Priority</a></li>-->
                         <li><a href="#" onClick="navigatePathTester()">Path Tester</a></li>
                         <li><a href="#" onClick="navigateEditGroups()">Edit Groups</a></li>
                     </ul>

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -17,7 +17,6 @@
             .detailsLeft
             {
                 float: left;
-                width: 40%;
                 overflow: hidden;
                 margin: 12px;
                 padding: 8px;
@@ -25,7 +24,6 @@
 
             .detailsRight
             {
-                width: 50%;
                 float: left;
                 margin: 12px;
                 margin-left: 0px;
@@ -36,26 +34,23 @@
                 padding: 12px;
             }
 
-            #details
-            {
-                position:fixed;
-                margin-left: 570px;
-                width:100%;
+            #container>div {
+                display:inline-block;
             }
 
             #listContainer
             {
                 min-width: 400px;
+                margin-right: 40px;
                 float: left;
             }
 
             #editDiv {
-                width: 45%;
                 display:none;
+                max-width: 40vw; /* ALLOWS FOR SCROLLING TO THE END OF THE DIV IF LARGER THAN WINDOW */
             }
 
             #serverEdit {
-                width: 60%;
                 display:none;
             }
 
@@ -529,6 +524,7 @@
                 $("#requestOverrideSelect").select2({dropdownAutoWidth : true});
 
                 var serverList = jQuery("#serverlist");
+                var initServerWidth = 0;
                 serverList.jqGrid({
                     autowidth : false,
                     caption : 'API Servers',
@@ -614,6 +610,9 @@
                             serverList.hideCol("hostsEntry.enabled");
                         }
                     },
+                    gridComplete: function() {
+                        initServerWidth = serverList.jqGrid('getGridParam', 'width');
+                    },
                     datatype : "json",
                     height: "100%",
                     hiddengrid: false,
@@ -691,7 +690,11 @@
                         return [true];
                     }
                 });
-                serverList.jqGrid('gridResize');
+                serverList.jqGrid('gridResize', {
+                    stop: function() {
+                        resizeGrid( "#serverlist", serverList, initServerWidth );
+                    }
+                });
 
                 var serverGroupList = jQuery("#serverGroupList");
                 serverGroupList.jqGrid({
@@ -774,6 +777,7 @@
                 serverGroupList.jqGrid('gridResize');
 
                 var grid = $("#packages");
+                var initGridWidth = 0;
                 grid.jqGrid({
                     autowidth: false,
                     caption: "Paths",
@@ -938,7 +942,16 @@
                          rp_ge.url = '<c:url value="/api/path/" />' + currentPathId + "?clientUUID=" + clientUUID;
                         }},
                     {});
-                grid.jqGrid('gridResize');
+                grid.jqGrid('gridResize', {
+                    stop: function() {
+                        resizeGrid( "#packages", grid, initServerWidth );
+                        var width = grid.jqGrid('getGridParam', 'width');
+                        var ratio = width/initServerWidth;
+                        var newSize = ratio + 'em';
+
+                        $(".ui-jqgrid #packages tr.jqgrow td").css('font-size', newSize);
+                    }
+                });
                 grid.jqGrid('filterToolbar', { defaultSearch: 'cn', stringResult: true });
 
                 /* ALLOWS THE PATH PRIORITY TO BE SET INSIDE OF THE PATH TABLE, INSTEAD OF ON A SEPARATE PAGE */
@@ -1061,6 +1074,24 @@
                         return "ex. /http500, /(a|b)"
                     default:
                         return null;
+                }
+            }
+
+            function resizeGrid( val, grid, init ) {
+                var width = grid.jqGrid('getGridParam', 'width');
+                var ratio = width/init;
+                var newSize = ratio + 'em';
+
+                var font = $(".ui-jqgrid "+val+" tr.jqgrow td");
+                $(font).css('font-size', newSize);
+
+                /* CHECK SIZE TO MAKE SURE IT'S NOT TOO BIG AND NOT TOO SMALL */
+                var min = 11;
+                var max = 16;
+                if(parseInt(font.css("fontSize")) < min ) {
+                    font.css('font-size', min);
+                } else if( parseInt(font.css("fontSize")) > max ) {
+                    font.css('fontSize', max);
                 }
             }
 
@@ -1802,6 +1833,7 @@
             </div>
         </nav>
 
+        <div id="container">
         <div id="listContainer">
             <div>
                 <table id="serverlist"></table>
@@ -2027,6 +2059,7 @@
 
                 </div>
             </div>
+        </div>
         </div>
     </body>
 </html>

--- a/proxyui/src/main/webapp/WEB-INF/views/history.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/history.jsp
@@ -279,7 +279,6 @@
                                         + filter,
                                 page : 1
                             }).trigger("reloadGrid");
-            $("#searchFilter").val("");
         }
 
         function showItemsWithMessages() {

--- a/proxyui/src/main/webapp/WEB-INF/views/pathOrder.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/pathOrder.jsp
@@ -23,6 +23,7 @@
     $("#sortable").sortable({
     	update: function(event, ui) {
 			var pathOrder = $('#sortable').sortable('toArray').toString();
+			console.log("Path order: "+pathOrder);
 			//alert(pathOrder);
 			$.ajax({
 				type: "POST",

--- a/proxyui/src/main/webapp/WEB-INF/views/profiles.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/profiles.jsp
@@ -8,6 +8,10 @@
         <title>API Profiles</title>
         <script type="text/javascript">
 
+        function navigateHelp() {
+            window.open("https://github.com/groupon/odo#readme","help");
+        }
+
         //makes the specific profile active, goes to the database column
         function makeActive(profile_id){
             $.ajax({
@@ -69,6 +73,8 @@
         }
 
         $(document).ready(function () {
+
+            $("#helpButton").tooltip();
 
             var profileList = jQuery("#profilelist");
             profileList
@@ -262,6 +268,10 @@
                             </ul>
                         </li>
                     </ul>
+                    <div class="form-group navbar-form navbar-left">
+                        <button id="helpButton" class="btn btn-info" onclick="navigateHelp()"
+                                target="_blank" data-toggle="tooltip" data-placement="bottom" title="Click here to read the readme.">Need Help?</button>
+                    </div>
                     <ul class="nav navbar-nav navbar-right">
                         <li>
                             <p class="navbar-text">Odo Version: <c:out value = "${version}"/></p>


### PR DESCRIPTION
    Allowed for toggling on and off reordering path priority on Edit Profile page.

    Changed help button destination to readme, instead of wiki.
    
    Added help button to profile page.

    Made it so opening Request History in the same profile over again will reopen in old tab, while opening it in new profile will open a new tab.

    Caused right div on Edit Profile page to move if jqGrids are resized to be larger.
    
    Added font-resizing functionality to Paths and API Servers jqGrids when table is resized.
    
    Allowed for scrolling if tabs div on right side of Edit Profile page is made larger than the screen.

    Changed so text stays in search box after submitting on Request History page.