### PR TITLE
UI Changes: moved clients to popup on Edit Profile page; other small changes

### DIFF
--- a/proxyui/src/main/webapp/WEB-INF/views/clients_part.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/clients_part.jsp
@@ -1,0 +1,227 @@
+<style type="text/css">
+    .ui-widget-content .selectedRow {
+        color: blue;
+    }
+</style>
+<script>
+var id = -1;
+function idFormatter( cellvalue, options, rowObject ) {
+	id = cellvalue;
+	return cellvalue;
+}
+
+var uuid;
+function uuidFormatter( cellvalue, options, rowObject ) {
+	uuid = cellvalue;
+	return cellvalue;
+}
+
+//formats the enable/disable check box
+function enabledFormatter( cellvalue, options, rowObject ) {
+	var checkedValue = 0;
+	if (cellvalue == true) {
+		checkedValue = 1;
+	}
+
+	var newCellValue = '<input id="enabled_' + id + '" onChange="enabledChanged(' + id + ', \'' + uuid + '\')" type="checkbox" offval="0" value="' + checkedValue + '"';
+
+	if (checkedValue == 1) {
+		newCellValue += 'checked="checked"';
+	}
+
+	newCellValue += '>';
+
+	return newCellValue;
+}
+
+//called when an enabled checkbox is changed
+function enabledChanged(id, uuid) {
+	var enabled = $("#enabled_" + id).is(":checked");
+
+	$.ajax({
+   		type:"POST",
+    	url: '<c:url value="/api/profile/${profile_id}/clients/"/>' + uuid,
+    	data: "active=" + enabled,
+    	success: function() {
+   			jQuery("#clientlist").trigger("reloadGrid");
+   		},
+   		error: function(xhr) {
+   			document.getElementById("enabled_" + id).checked = origEnabled;
+   			alert("Error updating client entry.");
+   		}
+    });
+}
+
+function manageClientPopup() {
+    $("#changeClientDialog").dialog({
+        title: "Manage Clients",
+        modal: true,
+        resizeable: true,
+        width:'auto',
+        height:'auto',
+        close: function() {
+            $("#changeClientFriendlyName").val("");
+            $("#switchClientName").val("");
+            $("#friendlyNameError").html("");
+        },
+        buttons: {
+            "Close": function () {
+                $("#changeClientDialog").dialog("close");
+            }
+        }
+    });
+}
+
+$(document).ready(function () {
+    var clientList = jQuery("#clientlist");
+    clientList
+    .jqGrid({
+        url : '<c:url value="/api/profile/${profile_id}/clients"/>',
+        autowidth : true,
+        rowList : [], // disable page size dropdown
+        pgbuttons : false, // disable page control like next, back button
+        pgtext : null,
+        multiselect:true,
+        multiboxonly:true,
+        cellEdit : true,
+        datatype : "json",
+        colNames : [ 'ID', 'UUID',
+            'Friendly Name', 'Active', 'Last Accessed' ],
+        colModel : [ {
+            name : 'id',
+            index : 'id',
+            width : 55,
+            hidden : true,
+            formatter: idFormatter
+        }, {
+            name: 'uuid',
+            path: 'uuid',
+            editable: false,
+            width: '300',
+            align: 'left',
+            formatter: uuidFormatter
+        }, {
+            name : 'friendlyName',
+            index : 'friendlyName',
+            width : 200,
+            editable : true
+        }, {
+            name: 'isActive',
+            path: 'isActive',
+            width: 36,
+            editable: true,
+            align: 'center',
+            edittype: 'checkbox',
+            formatter: enabledFormatter,
+            formatoptions: {disabled : false}
+        }, {
+            name: 'lastAccessedFormatted',
+            path: 'lastAccessedFormatted',
+            editable: false,
+            align: 'left'
+        }],
+        jsonReader : {
+            page : "page",
+            total : "total",
+            records : "records",
+            root : 'clients',
+            repeatitems : false
+        },
+        afterEditCell : function(rowid, cellname, value, iRow, iCol) {
+            var uuid = clientList.getCell(rowid, 'uuid');
+            console.log(rowid);
+            if (cellname == "friendlyName") {
+                clientList.setGridParam({
+                    cellurl : '<c:url value="/api/profile/${profile_id}/clients/"/>' + uuid
+                });
+            }
+        },
+        afterSaveCell : function() {
+            clientList.trigger("reloadGrid");
+        },
+        gridComplete: function() {
+            clientList.jqGrid('setGridHeight', 22 * clientList.jqGrid('getGridParam', 'records'));
+        },
+        rowattr: function(rowData, currentObj, rowId) { /* HIGHLIGHTS THE CURRENT CLIENT */
+            if( rowData.uuid === clientUUID ) {
+                return { "class": "selectedRow" };
+            }
+        },
+        cellurl : '<c:url value="/api/profile/${profile_id}/clients/"/>',
+        rowList : [],
+        rowNum: 100000,
+        pager : '#clientnavGrid',
+        sortname : 'id',
+        viewrecords : true,
+        sortorder : "desc",
+        //caption : '<font size="5">Clients: ${profile_name}</font>'
+    });
+    clientList.jqGrid('navGrid', '#clientnavGrid', {
+        edit : false,
+        add : true,
+        del : true,
+        addtext: "Add a new client",
+        deltext: "Delete a client"
+    },
+    {},
+    {
+        url: '<c:url value="/api/profile/${profile_id}/clients/"/>',
+        reloadAfterSubmit: true,
+        beforeShowForm: function(form) {
+            $('#tr_isActive', form).hide();
+        },
+        width: 450,
+        closeAfterAdd: true,
+        errorTextFormat: jsonErrorFormat
+    },
+    {
+        url: '<c:url value="/api/profile/{profileIdentifier}/clients/delete"/>',
+        mtype:"POST", reloadAfterSubmit:true, serializeDelData: function (postdata) {
+        return ""; // the body MUST be empty in DELETE HTTP requests
+    },
+        onclickSubmit: function(rp_ge,postdata) {
+            /* IDS GIVEN IN AS A STRING SEPARATED BY COMMAS.
+             SEPARATE INTO AN ARRAY.
+             */
+            var rowids = postdata.split(",");
+            console.log(postdata);
+
+            /* FOR EVERY ROW ID TO BE DELETED,
+             GET THE CORRESPONDING PROFILE ID.
+             */
+            var params = "profileIdentifier=${profile_id}&";
+            for( var i = 0; i < rowids.length; i++) {
+                var odoId = $(this).jqGrid('getCell', rowids[i], 'uuid');
+                params += "clientUUID=" + odoId + "&";
+            }
+
+            rp_ge.url = '<c:url value="/api/profile/{profileIdentifier}/clients/delete"/>?' +
+                    params;
+            console.log(rp_ge.url);
+        },
+        reloadAfterSubmit: true
+    });
+    clientList.jqGrid('gridResize');
+});
+</script>
+
+<!-- Hidden div for clients -->
+<div id="changeClientDialog" style="display:none">
+    <div id="clientContainer">
+        <b>Current client UUID: <font color="blue">${clientUUID}</font></b><br>
+        <table id="clientlist" style="width:100%"></table><br>
+        <div id="clientnavGrid"></div>
+        <table>
+            <tr>
+                <td>Client Friendly Name: </td><td><input id="changeClientFriendlyName"/></td>
+                <td><input type="button" id="changeFriendlyNameButton" onclick="changeClientFriendlyNameSubmit()" value="Change Current Friendly Name"/></td>
+            </tr><tr>
+                <td></td>
+                <td colspan="2"><div id="friendlyNameError" style="color: red"></div></td>
+            </tr><tr>
+                <td>Client UUID/Name: </td><td><input id="switchClientName"/></td>
+                <td><input type="button" id="changeClientButton" onclick="changeClientSubmit()" value="Change Client"/></td>
+            </tr>
+        </table>
+    </div>
+</div>

--- a/proxyui/src/main/webapp/WEB-INF/views/clients_part.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/clients_part.jsp
@@ -6,49 +6,49 @@
 <script>
 var id = -1;
 function idFormatter( cellvalue, options, rowObject ) {
-	id = cellvalue;
-	return cellvalue;
+    id = cellvalue;
+    return cellvalue;
 }
 
 var uuid;
 function uuidFormatter( cellvalue, options, rowObject ) {
-	uuid = cellvalue;
-	return cellvalue;
+    uuid = cellvalue;
+    return cellvalue;
 }
 
 //formats the enable/disable check box
 function enabledFormatter( cellvalue, options, rowObject ) {
-	var checkedValue = 0;
-	if (cellvalue == true) {
-		checkedValue = 1;
-	}
+    var checkedValue = 0;
+    if (cellvalue == true) {
+        checkedValue = 1;
+    }
 
-	var newCellValue = '<input id="enabled_' + id + '" onChange="enabledChanged(' + id + ', \'' + uuid + '\')" type="checkbox" offval="0" value="' + checkedValue + '"';
+    var newCellValue = '<input id="enabled_' + id + '" onChange="enabledChanged(' + id + ', \'' + uuid + '\')" type="checkbox" offval="0" value="' + checkedValue + '"';
 
-	if (checkedValue == 1) {
-		newCellValue += 'checked="checked"';
-	}
+    if (checkedValue == 1) {
+        newCellValue += 'checked="checked"';
+    }
 
-	newCellValue += '>';
+    newCellValue += '>';
 
-	return newCellValue;
+    return newCellValue;
 }
 
 //called when an enabled checkbox is changed
 function enabledChanged(id, uuid) {
-	var enabled = $("#enabled_" + id).is(":checked");
+    var enabled = $("#enabled_" + id).is(":checked");
 
-	$.ajax({
-   		type:"POST",
-    	url: '<c:url value="/api/profile/${profile_id}/clients/"/>' + uuid,
-    	data: "active=" + enabled,
-    	success: function() {
-   			jQuery("#clientlist").trigger("reloadGrid");
-   		},
-   		error: function(xhr) {
-   			document.getElementById("enabled_" + id).checked = origEnabled;
-   			alert("Error updating client entry.");
-   		}
+    $.ajax({
+        type:"POST",
+        url: '<c:url value="/api/profile/${profile_id}/clients/"/>' + uuid,
+        data: "active=" + enabled,
+        success: function() {
+            jQuery("#clientlist").trigger("reloadGrid");
+        },
+        error: function(xhr) {
+            document.getElementById("enabled_" + id).checked = origEnabled;
+            alert("Error updating client entry.");
+        }
     });
 }
 

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -123,18 +123,10 @@
                 var clientInfoHTML = "";
                 if (clientUUID == '-1') {
                     clientInfoHTML = "<li><a href='#' onclick='manageClientPopup()'>Client UUID: Default</a>";
-                    //clientInfoHTML = "<li class='dropdown'><a href='#' class='dropdown-toggle' data-toggle='dropdown'>Client UUID: Default<b class='caret'></b></a><ul class='dropdown-menu'>";
                 } else {
                     clientInfoHTML = "<li><a href='#' onclick='manageClientPopup()'>Client UUID: " + clientUUID + "</a>";
-                    //clientInfoHTML = "<li class='dropdown'><a href='#' class='dropdown-toggle' data-toggle='dropdown'>Client UUID: " + clientUUID + "<span class='caret'></span></a><ul class='dropdown-menu'>";
                 }
 
-                //if ("${clientFriendlyName}" != "")
-                //    clientInfoHTML += "(${clientFriendlyName})";
-
-                /*clientInfoHTML += '  <li><a href="#" onclick="changeClientPopup()">Change Client</a></li>';
-                clientInfoHTML += '  <li><a href="#" onclick="changeClientFriendlyNamePopup()">Set Friendly Name</a></li>';
-                clientInfoHTML += '  <li><a href="#" onclick="manageClients()">Manage Clients</a></li>';*/
                 clientInfoHTML += '</ul></li>'
                 clientInfo.html(clientInfoHTML);
             }

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -961,8 +961,7 @@
                 });
                 grid.jqGrid('filterToolbar', { defaultSearch: 'cn', stringResult: true });
 
-                /* ALLOWS THE PATH PRIORITY TO BE SET INSIDE OF THE PATH TABLE, INSTEAD OF ON A SEPARATE PAGE */
-                grid.jqGrid('sortableRows', {
+                var options = {
                     update: function(event, ui) {
                         var pathOrder = "";
                         var paths = grid.jqGrid('getRowData');
@@ -984,6 +983,26 @@
                         });
                     },
                     placeholder: "ui-state-highlight"
+                };
+
+                var curr = false;
+                grid.jqGrid('navButtonAdd', '#packagePager', {
+                    caption: "Reorder",
+                    buttonicon: "ui-icon-carat-2-n-s",
+                    title: "Toggle Reorder Path Priority",
+                    id: "reorder_packages",
+                    onClickButton: function() {
+                        curr = !curr;
+
+                        if( curr ) {
+                            /* ALLOWS THE PATH PRIORITY TO BE SET INSIDE OF THE PATH TABLE, INSTEAD OF ON A SEPARATE PAGE */
+                            grid.jqGrid('sortableRows', options);
+                            $("#reorder_packages").addClass("ui-state-highlight");
+                        } else {
+                            $("#packages tbody").sortable('destroy');
+                            $("#reorder_packages").removeClass("ui-state-highlight");
+                        }
+                    }
                 });
 
                 /* ADD PLACEHOLDER TO FILTER BAR */

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -54,6 +54,11 @@
                 display:none;
             }
 
+            #nav>li>a { /* MAKES THE PILLS SMALLER */
+                padding-top:3px !important;
+                padding-bottom:3px !important;
+            }
+
             /* This changes the color of the active pill */
             .nav-pills>li.active>a, .nav-pills>li.active>a:hover, .nav-pills>li.active>a:focus {
                 background-color:#e9e9e9 !important;

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -85,7 +85,7 @@
             var editServerGroupId = 0;
 
             function navigateHelp() {
-                window.open("https://github.com/groupon/odo/wiki","help");
+                window.open("https://github.com/groupon/odo#readme","help");
             }
 
             function navigateEditGroups() {0
@@ -1824,7 +1824,7 @@
                     <!-- TO FIND HELP -->
                     <div class="form-group navbar-form navbar-left">
                         <button id="helpButton" class="btn btn-info" onclick="navigateHelp()"
-                                target="_blank" data-toggle="tooltip" data-placement="bottom" title="Click here to read the wiki.">Need Help?</button>
+                                target="_blank" data-toggle="tooltip" data-placement="bottom" title="Click here to read the readme.">Need Help?</button>
                     </div>
 
                     <ul id="clientInfo" class="nav navbar-nav navbar-right">

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -116,17 +116,19 @@
                 var clientInfo = $("#clientInfo");
                 var clientInfoHTML = "";
                 if (clientUUID == '-1') {
-                    clientInfoHTML = "<li class='dropdown'><a href='#' class='dropdown-toggle' data-toggle='dropdown'>Client UUID: Default<b class='caret'></b></a><ul class='dropdown-menu'>";
+                    clientInfoHTML = "<li><a href='#' onclick='manageClientPopup()'>Client UUID: Default</a>";
+                    //clientInfoHTML = "<li class='dropdown'><a href='#' class='dropdown-toggle' data-toggle='dropdown'>Client UUID: Default<b class='caret'></b></a><ul class='dropdown-menu'>";
                 } else {
-                    clientInfoHTML = "<li class='dropdown'><a href='#' class='dropdown-toggle' data-toggle='dropdown'>Client UUID: " + clientUUID + "<span class='caret'></span></a><ul class='dropdown-menu'>";
+                    clientInfoHTML = "<li><a href='#' onclick='manageClientPopup()'>Client UUID: " + clientUUID + "</a>";
+                    //clientInfoHTML = "<li class='dropdown'><a href='#' class='dropdown-toggle' data-toggle='dropdown'>Client UUID: " + clientUUID + "<span class='caret'></span></a><ul class='dropdown-menu'>";
                 }
 
                 //if ("${clientFriendlyName}" != "")
                 //    clientInfoHTML += "(${clientFriendlyName})";
 
-                clientInfoHTML += '  <li><a href="#" onclick="changeClientPopup()">Change Client</a></li>';
+                /*clientInfoHTML += '  <li><a href="#" onclick="changeClientPopup()">Change Client</a></li>';
                 clientInfoHTML += '  <li><a href="#" onclick="changeClientFriendlyNamePopup()">Set Friendly Name</a></li>';
-                clientInfoHTML += '  <li><a href="#" onclick="manageClients()">Manage Clients</a></li>';
+                clientInfoHTML += '  <li><a href="#" onclick="manageClients()">Manage Clients</a></li>';*/
                 clientInfoHTML += '</ul></li>'
                 clientInfo.html(clientInfoHTML);
             }
@@ -1792,17 +1794,18 @@
         </script>
     </head>
     <body>
-    	<!-- Hidden div for changing client friendly name -->
+    	<!-- Hidden div for changing client friendly name --
         <div id="changeClientFriendlyNameDialog" style="display:none;">
             Client Friendly Name: <input id="changeClientFriendlyName" value="${clientFriendlyName}"/>
             <div id="friendlyNameError" style="color: red"></div>
         </div>
 
-        <!-- Hidden div for switching clients -->
+        <!-- Hidden div for switching clients --
         <div id="switchClientDialog" style="display:none;">
             Client UUID/Name: <input id="switchClientName" value="${clientFriendlyName}"/>
-        </div>
-        
+        </div>-->
+
+        <%@ include file="clients_part.jsp" %>
         <%@ include file="pathtester_part.jsp" %>
 
         <nav class="navbar navbar-default" role="navigation">

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -93,7 +93,7 @@
             }
 
             function navigateRequestHistory() {
-                window.open('<c:url value='/history/${profile_id}'/>?clientUUID=${clientUUID}', "request-history");
+                window.open('<c:url value='/history/${profile_id}'/>?clientUUID=${clientUUID}', '<c:url value='/history/${profile_id}'/>?clientUUID=${clientUUID}');
             }
 
             function navigateProfiles() {

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -47,7 +47,8 @@
 
             #editDiv {
                 display:none;
-                max-width: 40vw; /* ALLOWS FOR SCROLLING TO THE END OF THE DIV IF LARGER THAN WINDOW */
+                width: 45vw;
+                max-width: 45vw; /* ALLOWS FOR SCROLLING TO THE END OF THE DIV IF LARGER THAN WINDOW */
             }
 
             #serverEdit {
@@ -985,16 +986,16 @@
                     placeholder: "ui-state-highlight"
                 };
 
-                var curr = false;
+                var sortableAllowed = false;
                 grid.jqGrid('navButtonAdd', '#packagePager', {
                     caption: "Reorder",
                     buttonicon: "ui-icon-carat-2-n-s",
                     title: "Toggle Reorder Path Priority",
                     id: "reorder_packages",
                     onClickButton: function() {
-                        curr = !curr;
+                        sortableAllowed = !sortableAllowed;
 
-                        if( curr ) {
+                        if( sortableAllowed ) {
                             /* ALLOWS THE PATH PRIORITY TO BE SET INSIDE OF THE PATH TABLE, INSTEAD OF ON A SEPARATE PAGE */
                             grid.jqGrid('sortableRows', options);
                             $("#reorder_packages").addClass("ui-state-highlight");
@@ -1100,7 +1101,7 @@
                     case "dest":
                         return "ex. 123.45.67.890";
                     case "pathName":
-                        return "ex. Collections";
+                        return "ex. My Path Name";
                     case "path":
                         return "ex. /http500, /(a|b)"
                     default:

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -986,6 +986,11 @@
                     placeholder: "ui-state-highlight"
                 });
 
+                /* ADD PLACEHOLDER TO FILTER BAR */
+                $("#gs_pathName").val("Type here to filter columns.");
+                $("#gs_pathName").focus(function() {
+                    $("#gs_pathName").val("");
+                });
 
                 $("#tabs").tabs();
                 $("#tabs").css("overflow", "auto");

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -108,14 +108,6 @@
             function navigatePathPriority() {
                 window.location = '<c:url value = '/pathorder/${profile_id}'/>';
             }
-            
-            function navigateRequestHistory() {
-                window.open('<c:url value='/history/${profile_id}'/>?clientUUID=${clientUUID}', "_blank");
-            }
-
-            function navigateProfiles() {
-                window.location = '<c:url value='/profiles'/>';
-            }
 
             function updateStatus() {
                 var status = $("#status");
@@ -655,10 +647,10 @@
                     beforeShowForm: function(formid) {
                         /* CREATE PLACEHOLDERS FOR ADD FORM. */
                         /* INITIALLY, GRAY */
-                        $("#srcUrl").val("ex. groupon.com");
+                        $("#srcUrl").val(getExampleText("src"));
                         $("#srcUrl").css("color", "gray");
 
-                        $("#destUrl").val("ex. 123.45.67.890");
+                        $("#destUrl").val(getExampleText("dest"));
                         $("#destUrl").css("color", "gray");
                     },
                     afterShowForm: function(formid) {
@@ -899,7 +891,7 @@
                         },
                         afterComplete: function(data) {
                             reloadGrid("#packages");
-                            $("#statusNotificationText").html("Path added.  Don't forget to add a hostname <b>above</b> and<br>adjust <a href=\"#\" onClick=\"navigatePathPriority()\" style=\"color: blue\">Path Priorities</a>!");
+                            $("#statusNotificationText").html("Path added.  Don't forget to add a hostname <b>above</b> and<br>adjust path priorities by <b>dragging and dropping</b> rows<br>in the path table!");
                             $("#statusNotificationDiv").fadeIn();
                         },
                         beforeShowForm: function(data) {
@@ -907,10 +899,10 @@
 
                             /* CREATE PLACEHOLDERS FOR ADD FORM. */
                             /* INITIALLY, GRAY */
-                            $("#pathName").val("ex. Collections");
+                            $("#pathName").val(getExampleText("pathName"));
                             $("#pathName").css("color", "gray");
 
-                            $("#path").val("ex. /http500, /(a|b)");
+                            $("#path").val(getExampleText("path"));
                             $("#path").css("color", "gray");
                         },
                         afterShowForm: function(formid) {
@@ -948,6 +940,33 @@
                     {});
                 grid.jqGrid('gridResize');
                 grid.jqGrid('filterToolbar', { defaultSearch: 'cn', stringResult: true });
+
+                /* ALLOWS THE PATH PRIORITY TO BE SET INSIDE OF THE PATH TABLE, INSTEAD OF ON A SEPARATE PAGE */
+                grid.jqGrid('sortableRows', {
+                    update: function(event, ui) {
+                        var pathOrder = "";
+                        var paths = grid.jqGrid('getRowData');
+                        for( var i = 0; i < paths.length; i++ ) {
+                            if( i === paths.length - 1 ) {
+                                pathOrder += paths[i]["pathId"];
+                            } else {
+                                pathOrder += paths[i]["pathId"] + ",";
+                            }
+                        }
+                        $.ajax({
+                            type: "POST",
+                            url: '<c:url value="/pathorder/"/>${profile_id}',
+                            data: ({pathOrder : pathOrder}),
+                            success: function() {
+                                $('#info').html('Path Order Updated');
+                                $('#info').fadeOut(1).delay(50).fadeIn(150);
+                            }
+                        });
+                    },
+                    placeholder: "ui-state-highlight"
+                });
+
+
                 $("#tabs").tabs();
                 $("#tabs").css("overflow", "auto");
                 $("#tabs").css("min-height", "500px");
@@ -1030,8 +1049,23 @@
             });
             loadPath(currentPathId);
 
+            function getExampleText(item) {
+                switch(item) {
+                    case "src":
+                        return "ex. groupon.com";
+                    case "dest":
+                        return "ex. 123.45.67.890";
+                    case "pathName":
+                        return "ex. Collections";
+                    case "path":
+                        return "ex. /http500, /(a|b)"
+                    default:
+                        return null;
+                }
+            }
+
             function srcValidation(val, colname) {
-                if( val.trim() === "ex. groupon.com" ) {
+                if( val.trim() === getExampleText("src") ) {
                     return [false, "Please replace the example source hostname with a valid hostname."]
                 } else {
                     return [true, ""];
@@ -1039,7 +1073,7 @@
             }
 
             function destValidation(val, colname) {
-                if( val.trim() === "ex. 123.45.67.890" ) {
+                if( val.trim() === getExampleText("dest") ) {
                     return [false, "Please replace the example destination hostname with a valid hostname."]
                 } else {
                     return [true, ""];
@@ -1047,7 +1081,7 @@
             }
 
             function pathNameValidation(val, colname) {
-                if( val.trim() === "ex. Collections" ) {
+                if( val.trim() === getExampleText("pathName") ) {
                     return [false, "Please replace the example path name with a valid name."]
                 } else {
                     return [true, ""];
@@ -1055,7 +1089,7 @@
             }
 
             function pathValidation(val, colname) {
-                if( val.trim() === "ex. /http, /(a|b)" ) {
+                if( val.trim() === getExampleText("path") ) {
                     return [false, "Please replace the example destination hostname with a valid hostname."]
                 } else {
                     return [true, ""];
@@ -1747,7 +1781,7 @@
                         <li class="navbar-brand">Odo</li>
                         <li><a href="#" onClick="navigateProfiles()">Profiles</a> </li>
                         <li><a href="#" onClick="navigateRequestHistory()">Request History</a></li>
-                        <li id="navbarPathPriority"><a href="#" onClick="navigatePathPriority()">Path Priority</a></li>
+                        <!--<li id="navbarPathPriority"><a href="#" onClick="navigatePathPriority()">Path Priority</a></li>-->
                         <li><a href="#" onClick="navigatePathTester()">Path Tester</a></li>
                         <li><a href="#" onClick="navigateEditGroups()">Edit Groups</a></li>
                     </ul>

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -17,7 +17,6 @@
             .detailsLeft
             {
                 float: left;
-                width: 40%;
                 overflow: hidden;
                 margin: 12px;
                 padding: 8px;
@@ -25,7 +24,6 @@
 
             .detailsRight
             {
-                width: 50%;
                 float: left;
                 margin: 12px;
                 margin-left: 0px;
@@ -36,26 +34,23 @@
                 padding: 12px;
             }
 
-            #details
-            {
-                position:fixed;
-                margin-left: 570px;
-                width:100%;
+            #container>div {
+                display:inline-block;
             }
 
             #listContainer
             {
                 min-width: 400px;
+                margin-right: 40px;
                 float: left;
             }
 
             #editDiv {
-                width: 45%;
                 display:none;
+                max-width: 40vw; /* ALLOWS FOR SCROLLING TO THE END OF THE DIV IF LARGER THAN WINDOW */
             }
 
             #serverEdit {
-                width: 60%;
                 display:none;
             }
 
@@ -529,6 +524,7 @@
                 $("#requestOverrideSelect").select2({dropdownAutoWidth : true});
 
                 var serverList = jQuery("#serverlist");
+                var initServerWidth = 0;
                 serverList.jqGrid({
                     autowidth : false,
                     caption : 'API Servers',
@@ -614,6 +610,9 @@
                             serverList.hideCol("hostsEntry.enabled");
                         }
                     },
+                    gridComplete: function() {
+                        initServerWidth = serverList.jqGrid('getGridParam', 'width');
+                    },
                     datatype : "json",
                     height: "100%",
                     hiddengrid: false,
@@ -691,7 +690,11 @@
                         return [true];
                     }
                 });
-                serverList.jqGrid('gridResize');
+                serverList.jqGrid('gridResize', {
+                    stop: function() {
+                        resizeGrid( "#serverlist", serverList, initServerWidth );
+                    }
+                });
 
                 var serverGroupList = jQuery("#serverGroupList");
                 serverGroupList.jqGrid({
@@ -774,6 +777,7 @@
                 serverGroupList.jqGrid('gridResize');
 
                 var grid = $("#packages");
+                var initGridWidth = 0;
                 grid.jqGrid({
                     autowidth: false,
                     caption: "Paths",
@@ -938,7 +942,16 @@
                          rp_ge.url = '<c:url value="/api/path/" />' + currentPathId + "?clientUUID=" + clientUUID;
                         }},
                     {});
-                grid.jqGrid('gridResize');
+                grid.jqGrid('gridResize', {
+                    stop: function() {
+                        resizeGrid( "#packages", grid, initServerWidth );
+                        var width = grid.jqGrid('getGridParam', 'width');
+                        var ratio = width/initServerWidth;
+                        var newSize = ratio + 'em';
+
+                        $(".ui-jqgrid #packages tr.jqgrow td").css('font-size', newSize);
+                    }
+                });
                 grid.jqGrid('filterToolbar', { defaultSearch: 'cn', stringResult: true });
 
                 /* ALLOWS THE PATH PRIORITY TO BE SET INSIDE OF THE PATH TABLE, INSTEAD OF ON A SEPARATE PAGE */
@@ -1061,6 +1074,24 @@
                         return "ex. /http500, /(a|b)"
                     default:
                         return null;
+                }
+            }
+
+            function resizeGrid( val, grid, init ) {
+                var width = grid.jqGrid('getGridParam', 'width');
+                var ratio = width/init;
+                var newSize = ratio + 'em';
+
+                var font = $(".ui-jqgrid "+val+" tr.jqgrow td");
+                $(font).css('font-size', newSize);
+
+                /* CHECK SIZE TO MAKE SURE IT'S NOT TOO BIG AND NOT TOO SMALL */
+                var min = 11;
+                var max = 16;
+                if(parseInt(font.css("fontSize")) < min ) {
+                    font.css('font-size', min);
+                } else if( parseInt(font.css("fontSize")) > max ) {
+                    font.css('fontSize', max);
                 }
             }
 
@@ -1802,6 +1833,7 @@
             </div>
         </nav>
 
+        <div id="container">
         <div id="listContainer">
             <div>
                 <table id="serverlist"></table>
@@ -2027,6 +2059,7 @@
 
                 </div>
             </div>
+        </div>
         </div>
     </body>
 </html>

--- a/proxyui/src/main/webapp/WEB-INF/views/history.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/history.jsp
@@ -279,7 +279,6 @@
                                         + filter,
                                 page : 1
                             }).trigger("reloadGrid");
-            $("#searchFilter").val("");
         }
 
         function showItemsWithMessages() {

--- a/proxyui/src/main/webapp/WEB-INF/views/profiles.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/profiles.jsp
@@ -8,6 +8,10 @@
         <title>API Profiles</title>
         <script type="text/javascript">
 
+        function navigateHelp() {
+            window.open("https://github.com/groupon/odo#readme","help");
+        }
+
         //makes the specific profile active, goes to the database column
         function makeActive(profile_id){
             $.ajax({
@@ -69,6 +73,8 @@
         }
 
         $(document).ready(function () {
+
+            $("#helpButton").tooltip();
 
             var profileList = jQuery("#profilelist");
             profileList
@@ -262,6 +268,10 @@
                             </ul>
                         </li>
                     </ul>
+                    <div class="form-group navbar-form navbar-left">
+                        <button id="helpButton" class="btn btn-info" onclick="navigateHelp()"
+                                target="_blank" data-toggle="tooltip" data-placement="bottom" title="Click here to read the readme.">Need Help?</button>
+                    </div>
                     <ul class="nav navbar-nav navbar-right">
                         <li>
                             <p class="navbar-text">Odo Version: <c:out value = "${version}"/></p>


### PR DESCRIPTION
Allowed for toggling on and off reordering path priority on Edit Profile page.

Changed help button destination to readme, instead of wiki.

Added help button to profile page.

Made it so opening Request History in the same profile over again will reopen in old tab, while opening it in new profile will open a new tab.

Caused right div on Edit Profile page to move if jqGrids are resized to be larger.

Added font-resizing functionality to Paths and API Servers jqGrids when table is resized.

Allowed for scrolling if tabs div on right side of Edit Profile page is made larger than the screen.

Changed so text stays in search box after submitting on Request History page.

Allowed for toggling on and off reordering path priority on Edit Profile page.

Added placeholder to filter bar on Edit Profile page so it's clearer what the filter bar is for.

Made the Edit Profile pills smaller so it's easier to see when there are many pills.

Added clients_part.jsp file for Manage Clients dialog popup on Edit Profile page.