### PR TITLE
UI Changes

### DIFF
--- a/proxylib/src/main/java/com/groupon/odo/proxylib/ClientService.java
+++ b/proxylib/src/main/java/com/groupon/odo/proxylib/ClientService.java
@@ -382,7 +382,7 @@ public class ClientService {
     public Client setFriendlyName(int profileId, String clientUUID, String friendlyName) throws Exception {
         // first see if this friendlyName is already in use
         Client client = this.findClientFromFriendlyName(profileId, friendlyName);
-        if (client != null) {
+        if (client != null && !client.getUUID().equals(clientUUID)) {
             throw new Exception("Friendly name already in use");
         }
 

--- a/proxyui/src/main/java/com/groupon/odo/controllers/HistoryController.java
+++ b/proxyui/src/main/java/com/groupon/odo/controllers/HistoryController.java
@@ -17,6 +17,7 @@ package com.groupon.odo.controllers;
 
 import com.groupon.odo.proxylib.Constants;
 import com.groupon.odo.proxylib.HistoryService;
+import com.groupon.odo.proxylib.ProfileService;
 import com.groupon.odo.proxylib.Utils;
 import com.groupon.odo.proxylib.models.History;
 import org.slf4j.Logger;
@@ -44,6 +45,7 @@ public class HistoryController {
         model.addAttribute("offset", offset);
         model.addAttribute("clientUUID", clientUUID);
         model.addAttribute("historyID", historyID);
+        model.addAttribute("profile_name", ProfileService.getInstance().getNamefromId(profileId));
 
         Integer page = 1;
         if (historyID != -1) {

--- a/proxyui/src/main/webapp/WEB-INF/views/clients_part.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/clients_part.jsp
@@ -59,11 +59,6 @@ function manageClientPopup() {
         resizeable: true,
         width:'auto',
         height:'auto',
-        close: function() {
-            $("#changeClientFriendlyName").val("");
-            $("#switchClientName").val("");
-            $("#friendlyNameError").html("");
-        },
         buttons: {
             "Close": function () {
                 $("#changeClientDialog").dialog("close");
@@ -72,42 +67,73 @@ function manageClientPopup() {
     });
 }
 
-function changeClientSubmit() {
+function saveClientRow(id, active) {
+    $("#clientlist").jqGrid("setGridParam",
+            {
+                ajaxRowOptions: {
+                    url : '<c:url value="/api/profile/${profile_id}/clients/"/>'+$("#clientlist").jqGrid("getCell", id, "uuid")
+                }
+            });
+
+    var saveParameters = {
+        "successfunc" : null,
+        "url" : '<c:url value="/api/profile/${profile_id}/clients/"/>' + $("#clientlist").jqGrid("getCell", id, "uuid"),
+        "extraparam" : {
+            "active" : active
+        },
+        "aftersavefunc" : null,
+        "errorfunc": null,
+        "afterrestorefunc" : null,
+        "restoreAfterError" : true,
+        "mtype" : "POST"
+    }
+
+    $("#clientlist").jqGrid("saveRow", id, saveParameters);
+}
+
+function editClientRow(id) {
+    $("#clientlist").jqGrid("setGridParam",
+            {
+                ajaxRowOptions: {
+                    url : '<c:url value="/api/profile/${profile_id}/clients/"/>'+$("#clientlist").jqGrid("getCell", id, "uuid")
+                }
+            });
+
+    var editParameters = {
+        "oneditfunc" : null,
+        "successfunc" : null,
+        "url" : '<c:url value="/api/profile/${profile_id}/clients/"/>' + $("#clientlist").jqGrid("getCell", id, "uuid"),
+        "extraparam" : {},
+        "aftersavefunc" : null,
+        "errorfunc": null,
+        "afterrestorefunc" : null,
+        "restoreAfterError" : true,
+        "mtype" : "POST"
+    };
+
+    var checked = $("#enabled_"+id).is(":checked");
+    $("#clientlist").jqGrid("editRow", id, true, editParameters);
+    document.getElementById(id+"_isActive").checked = checked;
+}
+
+function changeClientSubmit(id) {
+    // check if active -- pretty sure this doesn't work properly
+    var active = $("#" + id + "_isActive").is(":checked");
+    console.log("active: "+active);
+
+    saveClientRow(id, active);
+
     $.removeCookie("UUID", { expires: 10000, path: '/testproxy/' });
-    var value = $('#switchClientName').val();
+    var value = $("#clientlist").jqGrid('getCell', id, "friendlyName");
+    if( value === "" ) {
+        value = $("#clientlist").jqGrid('getCell', id, 'uuid');
+    }
     var url = '<c:url value="/edit/${profile_id}"/>?clientUUID=' + value;
     window.location.href = url;
 }
 
-function changeClientFriendlyNameSubmit() {
-    var value = $('#changeClientFriendlyName').val();
-    if (value == "${clientFriendlyName}") {
-        $("#changeClientFriendlyNameDialog").dialog("close");
-        return;
-    }
-
-    $.ajax({
-        type:"POST",
-        url: '<c:url value="/api/profile/${profile_id}/clients/${clientUUID}"/>',
-        data: {friendlyName: value},
-        success: function() {
-            var url = '<c:url value="/edit/${profile_id}"/>?clientUUID=${clientUUID}';
-            window.location.href = url;
-        },
-        error: function(xhr) {
-            var json;
-            try {
-                json = $.parseJSON(xhr.responseText);
-                $("#friendlyNameError").html(json.error.message);
-            } catch(e) {
-                $("#friendlyNameError").html("An unknown error occurred");
-            }
-
-        }
-    });
-}
-
 $(document).ready(function () {
+    var lastSelected = -2;
     var clientList = jQuery("#clientlist");
     clientList
     .jqGrid({
@@ -118,10 +144,9 @@ $(document).ready(function () {
         pgtext : null,
         multiselect:true,
         multiboxonly:true,
-        cellEdit : true,
         datatype : "json",
         colNames : [ 'ID', 'UUID',
-            'Friendly Name', 'Active', 'Last Accessed' ],
+            'Friendly Name', 'Active', 'Last Accessed', 'Change Current' ],
         colModel : [ {
             name : 'id',
             index : 'id',
@@ -154,6 +179,9 @@ $(document).ready(function () {
             path: 'lastAccessedFormatted',
             editable: false,
             align: 'left'
+        }, {
+            name: 'selectButton',
+            width: 100
         }],
         jsonReader : {
             page : "page",
@@ -162,25 +190,44 @@ $(document).ready(function () {
             root : 'clients',
             repeatitems : false
         },
-        afterEditCell : function(rowid, cellname, value, iRow, iCol) {
-            var uuid = clientList.getCell(rowid, 'uuid');
-            console.log(rowid);
-            if (cellname == "friendlyName") {
-                clientList.setGridParam({
-                    cellurl : '<c:url value="/api/profile/${profile_id}/clients/"/>' + uuid
-                });
+        onCellSelect: function(id, iCol, cellcontent, e) {
+            // if the user has another row currently selected
+            if( id != lastSelected ) {
+                // keep track of whether or not the checkbox for isActive is checked
+                var active;
+                // and if there exists a last selected row, save the info edited in that row first
+                if( lastSelected != -2 ) {
+                    active = $("#" + lastSelected + "_isActive").is(":checked");
+                    saveClientRow(lastSelected, active);
+                    document.getElementById("enabled_"+lastSelected).checked = active;
+                }
+
+                // now edit the row that we wish to edit
+                editClientRow(id);
+
+                // update that our last selected row is this one
+                lastSelected = id;
             }
         },
-        afterSaveCell : function() {
+        afterSaveCell: function() {
             clientList.trigger("reloadGrid");
         },
         gridComplete: function() {
             clientList.jqGrid('setGridHeight', 22 * clientList.jqGrid('getGridParam', 'records'));
+
+            /* ADD A BUTTON TO EACH ROW */
+            var rows = clientList.jqGrid("getDataIDs");
+            for(var i = 0; i < rows.length; i++) {
+                clientList.jqGrid('setRowData', rows[i], {selectButton: "<input type='button' style='width:90px' value='Select' onclick='changeClientSubmit("+rows[i]+")'/>"});
+            }
         },
         rowattr: function(rowData, currentObj, rowId) { /* HIGHLIGHTS THE CURRENT CLIENT */
             if( rowData.uuid === clientUUID ) {
                 return { "class": "selectedRow" };
             }
+        },
+        ajaxRowOptions: {
+            url : '<c:url value="/api/profile/${profile_id}/clients/"/>'
         },
         cellurl : '<c:url value="/api/profile/${profile_id}/clients/"/>',
         rowList : [],
@@ -246,17 +293,5 @@ $(document).ready(function () {
         <b>Current client UUID: <font color="blue">${clientUUID}</font></b><br>
         <table id="clientlist" style="width:100%"></table><br>
         <div id="clientnavGrid"></div>
-        <table>
-            <tr>
-                <td>Client Friendly Name: </td><td><input id="changeClientFriendlyName"/></td>
-                <td><input type="button" id="changeFriendlyNameButton" onclick="changeClientFriendlyNameSubmit()" value="Change Current Friendly Name"/></td>
-            </tr><tr>
-                <td></td>
-                <td colspan="2"><div id="friendlyNameError" style="color: red"></div></td>
-            </tr><tr>
-                <td>Client UUID/Name: </td><td><input id="switchClientName"/></td>
-                <td><input type="button" id="changeClientButton" onclick="changeClientSubmit()" value="Change Client"/></td>
-            </tr>
-        </table>
     </div>
 </div>

--- a/proxyui/src/main/webapp/WEB-INF/views/history.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/history.jsp
@@ -3,8 +3,13 @@
 <%@ page session="false" %>
 <html>
 <head>
-    <title>History</title>
+    <title>History: ${profile_name}</title>
     <%@ include file="/resources/js/webjars.include" %>
+    <style type="text/css">
+        ul, li {
+            list-style-type: none;
+        }
+    </style>
     <script src="<c:url value="/resources/js/diff_match_patch_uncompressed.js" />"></script>
     <link rel="stylesheet" type="text/css" media="screen"
              href="<c:url value="/resources/css/odo.css"/>" />
@@ -790,7 +795,7 @@
                     sortname : 'id',
                     viewrecords : true,
                     sortorder : "desc",
-                    caption : '<font size="5">History</font>'
+                    caption : '<font size="5">History: ${profile_name}</font>'
                 });
 
         historyList.jqGrid('navGrid', '#historynavGrid', {

--- a/proxyui/src/main/webapp/WEB-INF/views/profiles.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/profiles.jsp
@@ -1,11 +1,21 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib prefix="form" uri="http://www.springframework.org/tags/form"%>
 <%@ page session="false" %>
-<html>
     <head>
         <%@ include file="/resources/js/webjars.include" %>
 
         <title>API Profiles</title>
+        <style type="text/css">
+            .ui-jqgrid tr.jqgrow td, #jqgh_profilelist_name { /* MAKE PROFILE NAMES BIGGER */
+                font-size: medium;
+            }
+
+            ul {
+                list-style-type: none;
+            }
+        </style>
         <script type="text/javascript">
 
         function navigateHelp() {


### PR DESCRIPTION
Re-sized font on Profiles page.

Prevented div wrapping in the details div on Edit Profile page and fixed Odo title on Profiles and Request History pages.

Details div now stays fixed next to table when scrolling in Chrome, Firefox, Safari.

Removed destination placeholder and friendly name change text input.

Added helper popup when reordering for paths is toggled on.

Corrected an error that occurs when typing in a destination hostname.

History's page title now shows what profile it is associated with.

Added profile name to historyList on Request History page.

Path group configuration is in a checklist now.

Added Select button to each row of Client list; removed need for text input to change clients.

Temporarily removed font-resizing feature -- will continue work on it later.

Temporarily made the details div bigger. Still trying to figure out if there's a way to make the width fill up remaining space.

If client has no friendly name, URL parameter will default to UUID.

Group selection for a path now fixed; added reset before adding selections.

Fixed bug where clients could not have friendly name being edited as Submit was being clicked.