### PR TITLE
Adding an environment variable to specify database maxActive pool.

### DIFF
--- a/proxylib/src/main/java/com/groupon/odo/proxylib/Constants.java
+++ b/proxylib/src/main/java/com/groupon/odo/proxylib/Constants.java
@@ -28,6 +28,7 @@ public class Constants {
     public static final String SYS_HTTP_PORT = "ODO_HTTP_PORT";
     public static final String SYS_HTTPS_PORT = "ODO_HTTPS_PORT";
     public static final String SYS_LOGGING_DISABLED = "ODO_DISABLE_HISTORY";
+    public static final String SYS_DATABASE_POOL_SIZE = "ODO_DB_POOL_SIZE";
     public static final int DEFAULT_API_PORT = 8090;
     public static final int DEFAULT_DB_PORT = 9092;
     public static final int DEFAULT_FWD_PORT = 9090;

--- a/proxylib/src/main/java/com/groupon/odo/proxylib/SQLService.java
+++ b/proxylib/src/main/java/com/groupon/odo/proxylib/SQLService.java
@@ -106,6 +106,13 @@ public class SQLService {
             _instance = new SQLService();
             _instance.startServer();
 
+            // default pool size is 20
+            // can be overriden by env variable
+            int dbPool = 20;
+            if (Utils.getEnvironmentOptionValue(Constants.SYS_DATABASE_POOL_SIZE) != null) {
+                dbPool = Integer.valueOf(Utils.getEnvironmentOptionValue(Constants.SYS_DATABASE_POOL_SIZE));
+            }
+
             // initialize connection pool
             PoolProperties p = new PoolProperties();
             String connectString = "jdbc:h2:tcp://" + _instance.databaseHost + ":" + String.valueOf(_instance.port) + "/" +
@@ -120,7 +127,7 @@ public class SQLService {
             p.setTestOnReturn(false);
             p.setValidationInterval(5000);
             p.setTimeBetweenEvictionRunsMillis(30000);
-            p.setMaxActive(20);
+            p.setMaxActive(dbPool);
             p.setInitialSize(5);
             p.setMaxWait(30000);
             p.setRemoveAbandonedTimeout(60);


### PR DESCRIPTION
Adding an environment variable to specify database maxActive pool(ODO_DB_POOL_SIZE)
Default is still 20