### PR TITLE
Fix: Change using priority to ordinal

### DIFF
--- a/proxylib/src/main/java/com/groupon/odo/proxylib/BackupService.java
+++ b/proxylib/src/main/java/com/groupon/odo/proxylib/BackupService.java
@@ -542,7 +542,8 @@ public class BackupService {
                         overrideService.enableOverride(overrideId, pathId, clientUUID);
                         overrideService.updateRepeatNumber(overrideId, pathId, override.getInt(Constants.PRIORITY),
                                                            override.getInt(Constants.REPEAT_NUMBER), clientUUID);
-                        overrideService.updateArguments(overrideId, pathId, override.getInt(Constants.PRIORITY), override.getString(Constants.ARGUMENTS), clientUUID);
+                        int overrideOrdinal = overrideService.getCurrentMethodOrdinal(overrideId, pathId, clientUUID, null);
+                        overrideService.updateArguments(overrideId, pathId, overrideOrdinal, override.getString(Constants.ARGUMENTS), clientUUID);
                     } catch (Exception e) {
                         errors.put(formErrorJson("Override Error", "Cannot add/update override: '" + overrideNameForError + "' - Check Override Exists"));
                         continue;

--- a/proxylib/src/main/java/com/groupon/odo/proxylib/OverrideService.java
+++ b/proxylib/src/main/java/com/groupon/odo/proxylib/OverrideService.java
@@ -626,6 +626,27 @@ public class OverrideService {
     }
 
     /**
+     * Get the ordinal value for the last of a particular override on a path
+     *
+     * @param overrideId Id of the override to check
+     * @param pathId Path the override is on
+     * @param clientUUID UUID of the client
+     * @param filters If supplied, only endpoints ending with values in filters are returned
+     * @return The integer ordinal
+     * @throws Exception
+     */
+    public int getCurrentMethodOrdinal(int overrideId, int pathId, String clientUUID, String[] filters) throws Exception {
+        int currentOrdinal = 0;
+        List<EnabledEndpoint> enabledEndpoints = getEnabledEndpoints(pathId, clientUUID, filters);
+        for (EnabledEndpoint enabledEndpoint : enabledEndpoints) {
+            if (enabledEndpoint.getOverrideId() == overrideId) {
+                currentOrdinal++;
+            }
+        }
+        return currentOrdinal;
+    }
+
+    /**
      * @param pathId ID of path
      * @param overrideId ID of override
      * @param ordinal Index of the enabled override to get if multiple of the same override are enabled(default is 1)


### PR DESCRIPTION
When uploading the backup, was using priority which is priority across all overrides for a path instead of ordinal which is order of specific overrides.  This uses the ordinal value now.