### PR TITLE
Fixing enabled overrides db migration issue

### DIFF
--- a/proxylib/src/main/java/com/groupon/odo/proxylib/Constants.java
+++ b/proxylib/src/main/java/com/groupon/odo/proxylib/Constants.java
@@ -38,7 +38,7 @@ public class Constants {
     public static final String ODO_INTERNAL_WEBAPP_URL = "http://odo";
 
     // DB constants
-    public static final int DB_CURRENT_SCHEMA_VERSION = 8;
+    public static final int DB_CURRENT_SCHEMA_VERSION = 9;
     public static final String DB_TABLE_CONFIGURATION = "configuration";
     public static final String DB_TABLE_HISTORY = "history";
     public static final String DB_TABLE_OVERRIDE = "override_db";

--- a/proxyui/src/main/resources/migrations/schema.9
+++ b/proxyui/src/main/resources/migrations/schema.9
@@ -1,0 +1,2 @@
+ALTER TABLE enabled_overrides_db DROP COLUMN response_code
+ALTER TABLE enabled_overrides_db ADD COLUMN (response_code VARCHAR(128) DEFAULT '200')


### PR DESCRIPTION
@dwillson @djrenfro 

Giving DEFAULT '200' so that overrides that don't have any value will get the default value of '200' custom status code.
Also, getting rid of "NOT NULL" Constraint, previously created in schema.8
Alter column function didn't work for me