### PR TITLE
Fix for | not working in request params

### DIFF
--- a/browsermob-proxy/pom.xml
+++ b/browsermob-proxy/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>com.squareup.okhttp</groupId>
       <artifactId>okhttp</artifactId>
-      <version>2.3.0</version>
+      <version>2.7.5</version>
     </dependency>
   </dependencies>
 

--- a/proxyserver/src/main/java/com/groupon/odo/Proxy.java
+++ b/proxyserver/src/main/java/com/groupon/odo/Proxy.java
@@ -607,7 +607,7 @@ public class Proxy extends HttpServlet {
         if (queryString == null) {
             queryString = "";
         } else {
-            queryString = "?" + queryString;
+            queryString = "?" + queryString.replace("|", "%7C");
         }
 
         // if this can't be overridden we are going to finish the string and bail


### PR DESCRIPTION
| in a request was throwing an exception.  Fix that by bumping dependency and manually encoding the | to %7C