### PR TITLE
bugfix: do not refresh page when applying history filter

### DIFF
--- a/proxyui/src/main/webapp/WEB-INF/views/history.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/history.jsp
@@ -292,17 +292,15 @@
     }
 
     function uriFilter() {
+        event.preventDefault();
         historyFilter = $("#searchFilter").val();
         $("#historylist")
-            .jqGrid(
-                'setGridParam',
-                {
-                    url : '<c:url value="/api/history/${profile_id}"/>?clientUUID=${clientUUID}&source_uri[]=' + historyFilter,
-                    page : 1
-                })
+            .jqGrid("setGridParam", {
+                url: '<c:url value="/api/history/${profile_id}"/>?clientUUID=${clientUUID}&source_uri[]=' + historyFilter,
+                page: 1
+            })
             .jqGrid('setCaption', historyCaption())
-            .trigger("reloadGrid")
-        return false; // prevent form redirection
+            .trigger("reloadGrid");
     }
 
     function showItemsWithMessages() {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3281451/53129713-27d36580-351d-11e9-8d8d-390a15fb063e.png)

Submitting the filter was originally causing a page refresh. We don't want that.