### PR TITLE
Improve the UX of request/response overrides on /edit

### DIFF
--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -353,6 +353,14 @@
                     $("#packages").setSelection(this.rowId, true);
                     // maintain focus on checkbox
                     $("#" + this.originalTargetId).focus();
+
+                    if (!this.isEnabled) return;
+
+                    if (overrideType == "response") {
+                        $("[href=\"#tabs-1\"]").click();
+                    } else {
+                        $("[href=\"#tabs-2\"]").click();
+                    }
                 }
             });
         }

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -201,26 +201,33 @@
 
             // TODO: Use foreach?
             var selectedRow = $("#packages").jqGrid("getGridParam", "selrow");
+            var pillsShown = false;
             $.each(ids, function(index, el) {
                 // TODO: Need cleaner way to do this
                 if (el.requestEnabled.indexOf("checked") + el.responseEnabled.indexOf("checked") > -2
                     || index + 1 == selectedRow) {
                     $("#nav").append($("<li>")
-                    .attr("id", el.pathId)
-                    .append($("<a>")
-                        .attr({
-                            "href": "#tab" + el.pathId,
-                            "data-toggle": "tab"})
-                        .text(el.pathName)
-                        .click(function() {
-                            loadPath($(this).parent().attr("id"));
-                        })));
+                        .attr("id", el.pathId)
+                        .append($("<a>")
+                            .attr({
+                                "href": "#tab" + el.pathId,
+                                "data-toggle": "tab"})
+                            .text(el.pathName)
+                            .click(function() {
+                                $("#packages").setSelection(index + 1, true);
+                            })));
+
+                    pillsShown = true;
                 }
             });
 
+            if (!pillsShown) {
+                loadPath(-1);
+                return;
+            }
+
             $("#nav").find("#" + currentPathId).addClass("active"); // TODO: Grey out the response pane if this is not found
             loadPath(currentPathId);
-            $("#editDiv").show();
         }
 
         // common function for grid reload
@@ -452,10 +459,20 @@
             });
             // Active paths navigation
             Mousetrap.bind('alt+right', function(event) {
-                $("#nav .active").next().find("a").click();
+                var $activeTab = $("#nav .active");
+                if ($activeTab.length) {
+                    $activeTab.next().find("a").click();
+                } else {
+                    $("#nav li").first().find("a").click();
+                }
             });
             Mousetrap.bind('alt+left', function(event) {
-                $("#nav .active").prev().find("a").click();
+                var $activeTab = $("#nav .active");
+                if ($activeTab.length) {
+                    $activeTab.prev().find("a").click();
+                } else {
+                    $("#nav li").first().find("a").click();
+                }
             });
             // Overrides navigation
             Mousetrap.bind('+', function(event) {

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -273,20 +273,21 @@
             var pillsShown = false;
             $.each(rowIds, function(_index_, rowId) {
                 var rowInfo = rowData[parseInt(rowId) - 1];
-                if (rowInfo.requestEnabled || rowInfo.responseEnabled || rowId == selectedRow) {
-                    $("#nav").append($("<li>")
-                        .attr("id", rowInfo.pathId)
-                        .append($("<a>")
-                            .attr({
-                                "href": "#tab" + rowInfo.pathId,
-                                "data-toggle": "tab"})
-                            .text(rowInfo.pathName)
-                            .click(function() {
-                                $("#packages").setSelection(rowId, true);
-                            })));
-
-                    pillsShown = true;
+                if (!(rowInfo.requestEnabled || rowInfo.responseEnabled || rowId == selectedRow)) {
+                    return;
                 }
+                $("#nav").append($("<li>")
+                    .attr("id", rowInfo.pathId)
+                    .append($("<a>")
+                        .attr({
+                            href: "#tab" + rowInfo.pathId,
+                            "data-toggle": "tab"})
+                        .text(rowInfo.pathName)
+                        .click(function() {
+                            $("#packages").setSelection(rowId, true);
+                        })));
+
+                pillsShown = true;
             });
 
             if (!pillsShown) {

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -75,21 +75,20 @@
         }
 
         #packages td input[type=checkbox]:focus  + label {
-            /* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#0a0e0a+0,0a0809+100&0+0,0+93,1+94,1+100 */
-            background: linear-gradient(135deg, rgba(0,0,0,0) 0%,rgba(0,0,0,0) 88%,black 90%,black 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+            background: linear-gradient(135deg, rgba(0,0,0,0) 88%, #cc1111 90%);
         }
 
         #packages td input[type=checkbox]:focus:active  + label {
-            background: linear-gradient(135deg, #bbddee 0%,#bbddee 88%,black 90%,black 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+            background: linear-gradient(135deg, #bbddee 88%, #cc1111 90%);
         }
 
         #packages td input[type=checkbox]:checked:focus  + label {
             /* gradient with blue background */
-            background: linear-gradient(135deg, #3399cc 0%,#3399cc 88%,black 90%,black 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+            background: linear-gradient(135deg, #3399cc 88%, white 90%);
         }
 
         #packages td input[type=checkbox]:checked:focus:active  + label {
-            background: linear-gradient(135deg, #cce6f2 0%,#cce6f2 88%,black 90%,black 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+            background: linear-gradient(135deg, #cce6f2 88%, white 90%);
         }
 
         #nav > li > a {
@@ -483,6 +482,40 @@
                 event.preventDefault();
                 $("#gs_pathName").focus();
             });
+            // Request/response override toggle navigation
+            Mousetrap.bind(['left', 'right', 'up', 'down'], function(event) {
+                var $focusedCheckbox = $("#packages td input[type=checkbox]:focus");
+                if (!$focusedCheckbox.length) return;
+
+                var $closestTd = $focusedCheckbox.closest("td");
+                switch (event.key) {
+                    case "ArrowLeft":
+                        if ($closestTd.attr("aria-describedby") == "packages_requestEnabled") { // todo: use indexof matching instead?
+                            $closestTd.prev("td").find("input:checkbox").focus();
+                        } else {
+                            $closestTd.closest("tr").prev("tr").find("td[aria-describedby=packages_requestEnabled] input:checkbox").focus();
+                        }
+                        break;
+                    case "ArrowRight":
+                        if ($closestTd.attr("aria-describedby") == "packages_responseEnabled") { // todo: use indexof matching instead?
+                            $closestTd.next("td").find("input:checkbox").focus();
+                        } else {
+                            $closestTd.closest("tr").next("tr").find("td[aria-describedby=packages_responseEnabled] input:checkbox").focus();
+                        }
+                        break;
+                    case "ArrowUp":
+                        var describedBy = $closestTd.attr("aria-describedby");
+                        $closestTd.closest("tr").prev("tr").find("td[aria-describedby=" + describedBy + "] input:checkbox").focus();
+                        break;
+                    case "ArrowDown":
+                        var describedBy = $closestTd.attr("aria-describedby");
+                        $closestTd.closest("tr").next("tr").find("td[aria-describedby=" + describedBy + "] input:checkbox").focus();
+                        break;
+                    default: return; break;
+                }
+
+                event.preventDefault();
+            });
             // Active paths navigation
             Mousetrap.bind('alt+right', function(event) {
                 var $activeTab = $("#nav .active");
@@ -774,7 +807,7 @@
                     {
                         name: 'pathName',
                         index: 'pathName',
-                        width: 330,
+                        width: 400,
                         editable: true,
                         editrules: {
                             required: true
@@ -801,7 +834,7 @@
                         name: 'requestType',
                         index: 'requestType',
                         align: 'center',
-                        width: 80,
+                        width: 60,
                         editable: true,
                         edittype: 'select',
                         editoptions: {

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -29,6 +29,43 @@
             width: auto !important;
         }
 
+        /* custom styling for response/request enabled cells */
+        #packages td input[type=checkbox] {
+            position: absolute;
+            z-index: -9999;
+            width: 0;
+            height: 0;
+        }
+
+        #packages td label[for] {
+            display: block;
+            font-weight: normal;
+            height: 100%;
+            width: 100%;
+            margin-bottom: 0;
+            cursor: pointer;
+            font-size: 1.333333333em;
+        }
+
+        #packages td input[type=checkbox]:focus  + label,
+        #packages td input[type=checkbox]:active + label {
+            outline: 2px solid blue;
+        }
+
+        #packages td input[type=checkbox] + label:before {
+            content: "✗";
+            color: #aaa;
+        }
+
+        #packages td input[type=checkbox]:checked + label {
+            background-color: green;
+        }
+
+        #packages td input[type=checkbox]:checked + label:before {
+            content: "✔";
+            color: white;
+        }
+
         #nav > li > a {
             padding-top: 3px;
             padding-bottom: 3px;
@@ -242,24 +279,21 @@
 
         function responseEnabledFormatter(cellvalue, options, rowObject) {
             var elementId = "response_enabled_" + rowObject.pathId;
-            return $("<div>").append(
-                $("<label>")
+
+            return $("<div>")
+                .append($("<input>")
                     .attr({
-                        for: elementId,
-                        style: "display: inline-block; height: 100%; width: 100%; margin: 0; padding: 0;"
+                        type: "checkbox",
+                        id: elementId,
+                        onchange: "responseEnabledChanged(" + elementId + ")",
+                        checked: cellvalue,
+                        offval: "0",
+                        "data-path": rowObject.pathId,
+                        "data-row": options.rowId
                     })
-                    .append($("<input>")
-                        .attr({
-                            type: "checkbox",
-                            id: elementId,
-                            onchange: "responseEnabledChanged(" + elementId + ")",
-                            checked: cellvalue,
-                            offval: "0",
-                            "data-path": rowObject.pathId,
-                            "data-row": options.rowId
-                        })
-                        .addClass("mousetrap")
-                        .val(cellvalue ? "1" : "0")))
+                    .addClass("mousetrap")
+                    .val(cellvalue ? "1" : "0"))
+                .append($("<label>").attr("for", elementId))
                 .html();
         }
 
@@ -287,24 +321,20 @@
 
         function requestEnabledFormatter(cellvalue, options, rowObject) {
             var elementId = "request_enabled_" + rowObject.pathId;
-            return $("<div>").append(
-                $("<label>")
+            return $("<div>")
+                .append($("<input>")
                     .attr({
-                        for: elementId,
-                        style: "display: inline-block; height: 100%; width: 100%; margin: 0; padding: 0;"
+                        type: "checkbox",
+                        id: elementId,
+                        onchange: "requestEnabledChanged(" + elementId + ")",
+                        checked: cellvalue,
+                        offval: "0",
+                        "data-path": rowObject.pathId,
+                        "data-row": options.rowId
                     })
-                    .append($("<input>")
-                        .attr({
-                            type: "checkbox",
-                            id: elementId,
-                            onchange: "requestEnabledChanged(" + elementId + ")",
-                            checked: cellvalue,
-                            offval: "0",
-                            "data-path": rowObject.pathId,
-                            "data-row": options.rowId
-                        })
-                        .addClass("mousetrap")
-                        .val(cellvalue ? "1" : "0")))
+                    .addClass("mousetrap")
+                    .val(cellvalue ? "1" : "0"))
+                .append($("<label>").attr("for", elementId))
                 .html();
         }
 
@@ -798,7 +828,7 @@
                     {
                         name: 'responseEnabled',
                         index: 'responseEnabled',
-                        width: "60",
+                        width: 50,
                         align: 'center',
                         editable: false,
                         formatter: responseEnabledFormatter,
@@ -811,7 +841,7 @@
                     }, {
                         name: 'requestEnabled',
                         index: 'requestEnabled',
-                        width: "60",
+                        width: 50,
                         align: 'center',
                         editable: false,
                         formatter: requestEnabledFormatter,

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -51,10 +51,6 @@
             color: #aaa;
         }
 
-        #packages td input[type=checkbox]:active + label {
-            background-color: #bbddee;
-        }
-
         #packages td input[type=checkbox]:active:checked + label:before,
         #packages td input[type=checkbox] + label:before {
             content: "✗";
@@ -65,8 +61,9 @@
             color: white;
         }
 
+        #packages td input[type=checkbox]:active + label,
         #packages td input[type=checkbox]:active:checked + label {
-            background-color: #cce6f2;
+            background-color: #bbddee;
         }
 
         #packages td input[type=checkbox]:active + label:before,
@@ -74,21 +71,31 @@
             content: "✔";
         }
 
-        #packages td input[type=checkbox]:focus  + label {
-            background: linear-gradient(135deg, rgba(0,0,0,0) 88%, #cc1111 90%);
+        #packages td input[type=checkbox]:focus  + label,
+        #packages td input[type=checkbox]:hover  + label {
+            color: #777;
         }
 
-        #packages td input[type=checkbox]:focus:active  + label {
-            background: linear-gradient(135deg, #bbddee 88%, #cc1111 90%);
+        #packages td input[type=checkbox]:focus  + label {
+            background: linear-gradient(315deg, #cc1111 5px, rgba(0,0,0,0) 6px);
+        }
+
+        #packages td input[type=checkbox]:checked:hover  + label {
+            background-color: #1177aa;
+            color: white;
         }
 
         #packages td input[type=checkbox]:checked:focus  + label {
-            /* gradient with blue background */
-            background: linear-gradient(135deg, #3399cc 88%, white 90%);
+            background: linear-gradient(315deg, white 5px, #1177aa 6px);
+            color: #eee;
         }
 
-        #packages td input[type=checkbox]:checked:focus:active  + label {
-            background: linear-gradient(135deg, #cce6f2 88%, white 90%);
+        #packages td input[type=checkbox]:focus:active  + label,
+        #packages td input[type=checkbox]:hover:active  + label,
+        #packages td input[type=checkbox]:checked:focus:active  + label,
+        #packages td input[type=checkbox]:checked:focus:hover:active  + label,
+        #packages td input[type=checkbox]:checked:hover:active  + label {
+            background: linear-gradient(315deg, white 5px, #bbddee 6px);
         }
 
         #nav > li > a {

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -1282,8 +1282,8 @@
                     changeResponseOverrideDiv();
                     changeRequestOverrideDiv();
 
-                    setResponseOverrideActiveIndication(data.responseEnabled);
-                    setRequestOverrideActiveIndication(data.requestEnabled);
+                    setResponseOverridesActiveIndicator(data.responseEnabled);
+                    setRequestOverridesActiveIndicator(data.requestEnabled);
 
                     // reset informational divs
                     $('#applyPathChangeSuccessDiv').hide();
@@ -1435,32 +1435,14 @@
             }
         }
 
-        function setResponseOverrideActiveIndication(isEnabled) {
-            $("#tabs-1 .panel-title").empty();
-
-            if (isEnabled) {
-                $("#tabs-1 .panel").removeClass("panel-default").addClass("panel-info");
-                $("#tabs-1 .panel-title").text("Response Overrides");
-            } else {
-                $("#tabs-1 .panel").removeClass("panel-info").addClass("panel-default");
-                $("#tabs-1 .panel-title")
-                    .text("Response Overrides ")
-                    .append($("<span>").attr("class", "label label-default").text("Inactive"));
-            }
+        function setResponseOverridesActiveIndicator(isResponseEnabled) {
+            $("#tabs-1 .panel").toggleClass("panel-default", !isResponseEnabled).toggleClass("panel-info", isResponseEnabled);
+            $("#tabs-1 .panel-title .label").toggle(!isResponseEnabled);
         }
 
-        function setRequestOverrideActiveIndication(isEnabled) {
-            $("#tabs-2 .panel-title").empty();
-
-            if (isEnabled) {
-                $("#tabs-2 .panel").removeClass("panel-default").addClass("panel-info");
-                $("#tabs-2 .panel-title").text("Request Overrides");
-            } else {
-                $("#tabs-2 .panel").removeClass("panel-info").addClass("panel-default");
-                $("#tabs-2 .panel-title")
-                    .text("Request Overrides ")
-                    .append($("<span>").attr("class", "label label-default").text("Inactive"));
-            }
+        function setRequestOverridesActiveIndicator(isRequestEnabled) {
+            $("#tabs-2 .panel").toggleClass("panel-default", !isRequestEnabled).toggleClass("panel-info", isRequestEnabled);
+            $("#tabs-2 .panel-title .label").toggle(!isRequestEnabled);
         }
 
         // get the next available ordinal for methodId on a specific path
@@ -2098,7 +2080,10 @@
                                 <div class="col-xs-5">
                                     <div class="panel">
                                         <div class="panel-heading">
-                                            <h3 class="panel-title">Response Overrides</h3>
+                                            <h3 class="panel-title">
+                                                <span>Response Overrides</span>
+                                                <span class="label label-default label-medsmall">Inactive</span>
+                                            </h3>
                                         </div>
                                         <div class="panel-body">
                                             <select id="responseOverrideEnabled" class="form-control mousetrap" multiple="multiple" style="height: 200px; resize: vertical;" onChange="changeResponseOverrideDiv()"></select>
@@ -2136,7 +2121,10 @@
                                 <div class="col-xs-5">
                                     <div class="panel">
                                         <div class="panel-heading">
-                                            <h3 class="panel-title">Request Overrides</h3>
+                                            <h3 class="panel-title">
+                                                <span>Request Overrides</span>
+                                                <span class="label label-default label-medsmall">Inactive</span>
+                                            </h3>
                                         </div>
                                         <div class="panel-body">
                                             <select id="requestOverrideEnabled" class="form-control mousetrap" multiple="multiple" style="height: 200px; resize: vertical;" onChange="changeRequestOverrideDiv()"></select>

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -1184,8 +1184,7 @@
                 type: "GET",
                 url: '<c:url value="/api/path/"/>' + pathId,
                 data: 'clientUUID=${clientUUID}',
-                success: function(data){
-
+                success: function(data) {
                     // populate Configuration values
                     $("#editDiv").show();
                     $("#pathName").attr("value", data.pathName);
@@ -1208,6 +1207,10 @@
                     populateEnabledOverrides();
                     changeResponseOverrideDiv();
                     changeRequestOverrideDiv();
+
+                    // TODO: Move elsewhere
+                    setResponseOverrideActiveIndication(data.responseEnabled);
+                    setRequestOverrideActiveIndication(data.requestEnabled);
 
                     // reset informational divs
                     $('#applyPathChangeSuccessDiv').hide();
@@ -1356,6 +1359,34 @@
                 selectedRequestOverride = 0;
                 $("#requestOverrideParameters").empty();
                 $("#requestOverrideDetails").hide();
+            }
+        }
+
+        function setResponseOverrideActiveIndication(isEnabled) {
+            $("#tabs-1 .panel-title").empty();
+
+            if (isEnabled) {
+                $("#tabs-1 .panel").removeClass("panel-default").addClass("panel-info");
+                $("#tabs-1 .panel-title").text("Response Overrides");
+            } else {
+                $("#tabs-1 .panel").removeClass("panel-info").addClass("panel-default");
+                $("#tabs-1 .panel-title")
+                    .text("Response Overrides ")
+                    .append($("<span>").attr("class", "label label-default").text("Inactive"));
+            }
+        }
+
+        function setRequestOverrideActiveIndication(isEnabled) {
+            $("#tabs-2 .panel-title").empty();
+
+            if (isEnabled) {
+                $("#tabs-2 .panel").removeClass("panel-default").addClass("panel-info");
+                $("#tabs-2 .panel-title").text("Request Overrides");
+            } else {
+                $("#tabs-2 .panel").removeClass("panel-info").addClass("panel-default");
+                $("#tabs-2 .panel-title")
+                    .text("Request Overrides ")
+                    .append($("<span>").attr("class", "label label-default").text("Inactive"));
             }
         }
 
@@ -1960,7 +1991,7 @@
                         <div id="tabs-1" class="container-flex">
                             <div class="row">
                                 <div class="col-xs-5">
-                                    <div class="panel panel-info">
+                                    <div class="panel">
                                         <div class="panel-heading">
                                             <h3 class="panel-title">Response Overrides</h3>
                                         </div>
@@ -1998,7 +2029,7 @@
                         <div id="tabs-2" class="container-flex">
                             <div class="row">
                                 <div class="col-xs-5">
-                                    <div class="panel panel-info">
+                                    <div class="panel">
                                         <div class="panel-heading">
                                             <h3 class="panel-title">Request Overrides</h3>
                                         </div>

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -1833,6 +1833,11 @@
                         },
                         success: function() {
                             toggleFormSubmitEnabled($(event.target), false);
+                            if (type == "request") {
+                                populateEnabledRequestOverrides();
+                            } else {
+                                populateEnabledResponseOverrides();
+                            }
                         },
                         error: function(err) {
                             debugger;

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -191,7 +191,7 @@
 
         // Keeps the list of pills updated
         function updateDetailPills() {
-            var ids = $("#packages").jqGrid('getDataIDs');
+            var ids = $("#packages").jqGrid('getRowData');
 
             $(".nav-pills > li").remove();
             if (ids.length === 0) {
@@ -199,34 +199,13 @@
                 return;
             }
 
-            var overridesToShow = []; // keep track of active and selected overrides
-
-            // Add the active override as the first item
-            if (currentPathId > -1) {
-                var rowId = $("#response_enabled_" + currentPathId).attr("data-row");
-                var currentRowData = $("#packages").jqGrid("getRowData", rowId);
-                if (currentRowData !== undefined) {
-                    overridesToShow.push(currentRowData);
-                    ids.splice(ids.indexOf(rowId), 1);
-                }
-            }
-
             // TODO: Use foreach?
+            var selectedRow = $("#packages").jqGrid("getGridParam", "selrow");
             $.each(ids, function(index, el) {
-                var rowdata = $("#packages").getRowData(el);
-                // TODO: If possible to glean from rowdata alone vs. expensive dom checks
-                if ($("#request_enabled_" + rowdata.pathId).is(":checked") || $("#response_enabled_" + rowdata.pathId).is(":checked")) {
-                    overridesToShow.push(rowdata);
-                }
-            });
-
-            if (!overridesToShow.length) {
-                loadPath(-1);
-                return;
-            }
-
-            $.each(overridesToShow, function(index, el) {
-                $("#nav").append($("<li>")
+                // TODO: Need cleaner way to do this
+                if (el.requestEnabled.indexOf("checked") + el.responseEnabled.indexOf("checked") > -2
+                    || index + 1 == selectedRow) {
+                    $("#nav").append($("<li>")
                     .attr("id", el.pathId)
                     .append($("<a>")
                         .attr({
@@ -236,6 +215,7 @@
                         .click(function() {
                             loadPath($(this).parent().attr("id"));
                         })));
+                }
             });
 
             $("#nav").find("#" + currentPathId).addClass("active"); // TODO: Grey out the response pane if this is not found

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -200,7 +200,6 @@
                 return;
             }
 
-            // TODO: Use foreach?
             var selectedRow = $("#packages").jqGrid("getGridParam", "selrow");
             var pillsShown = false;
             $.each(rowIds, function(_index_, rowId) {
@@ -226,7 +225,7 @@
                 return;
             }
 
-            $("#nav").find("#" + currentPathId).addClass("active"); // TODO: Grey out the response pane if this is not found
+            $("#nav").find("#" + currentPathId).addClass("active");
             loadPath(currentPathId);
         }
 
@@ -1208,7 +1207,6 @@
                     changeResponseOverrideDiv();
                     changeRequestOverrideDiv();
 
-                    // TODO: Move elsewhere
                     setResponseOverrideActiveIndication(data.responseEnabled);
                     setRequestOverrideActiveIndication(data.requestEnabled);
 

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -905,7 +905,7 @@
                     root : 'paths',
                     repeatitems : false
                 },
-                height: "auto",
+                height: "50vh",
                 ignoreCase: true,
                 loadonce: true,
                 beforeSelectRow: function(rowid, event) {
@@ -918,20 +918,24 @@
                     updateDetailPills();
 
                     var $rowElement = $("tr#" + id);
-
-                    if (!$rowElement.find(":checkbox").is(":focus") &&
-                        !$(this).closest(".ui-jqgrid-view").find(".ui-search-toolbar input").is(":focus")) {
-                        $rowElement.find(":checkbox").first().focus();
-                    }
-
-                    var docViewTop = $(window).scrollTop();
-                    var docViewBottom = docViewTop + $(window).height();
+                    var $packageScroller = $(this).closest(".ui-jqgrid-bdiv");
 
                     var elemTop = $rowElement.offset().top;
                     var elemBottom = elemTop + $rowElement.height();
 
-                    if ((elemBottom <= docViewBottom) && (elemTop >= docViewTop)) {
-                        return;
+                    var packagesScrollerTop = $packageScroller.offset().top;
+                    var packagesScrollerBottom = packagesScrollerTop + $packageScroller.height();
+
+                    if (elemBottom >= packagesScrollerBottom || elemTop <= packagesScrollerTop) {
+                        var scrollDiff = $rowElement.offset().top - $packageScroller.offset().top;
+                        $packageScroller.animate({
+                            scrollTop: $packageScroller.scrollTop() + scrollDiff - $packageScroller.height() / 2
+                        }, 100);
+                    }
+
+                    if (!$rowElement.find(":checkbox").is(":focus") &&
+                        !$(this).closest(".ui-jqgrid-view").find(".ui-search-toolbar input").is(":focus")) {
+                        $rowElement.find(":checkbox").first().focus();
                     }
                 },
                 loadComplete: function() {

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -1144,7 +1144,17 @@
                 $("#packages").setGridWidth($("#listContainer").width());
             });
 
-            $("#tabs").tabs();
+            $("#tabs").tabs({
+                activate: function (event, ui) {
+                    ui.newTab.blur();
+                },
+            });
+            $("#tabs a").click(function () {
+                $(this).blur();
+            });
+            $(".ui-tabs-tab").focus(function() {
+                $(this).blur();
+            });
             $("#sel1").select2();
 
             $("#gview_serverlist .ui-jqgrid-titlebar")

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -1699,8 +1699,8 @@
                             .attr("type", "reset")
                             .text("Clear"))
                         .submit(function(e) {
-                            submitOverrideData(type, parseInt(pathId), parseInt(methodId), parseInt(ordinal), data.enabledEndpoint.methodInformation.methodArguments.length);
                             e.preventDefault();
+                            submitOverrideData(type, parseInt(pathId), parseInt(methodId), parseInt(ordinal), data.enabledEndpoint.methodInformation.methodArguments.length);
                         });
 
                     $("#" + type + "OverrideParameters").empty().append($formData).show();
@@ -1735,7 +1735,6 @@
 
             $.ajax({
                 type: "POST",
-                async: false,
                 url: '<c:url value="/api/path/"/>' + currentPathId,
                 data: {
                     clientUUID: "${clientUUID}",
@@ -1768,45 +1767,11 @@
         }
 
         function submitOverrideData(type, pathId, methodId, ordinal, numArgs) {
-            submitEndPointArgs(type, pathId, methodId, ordinal, numArgs);
-            submitOverrideRepeatCountAndResponseCode(type, pathId, methodId, ordinal);
-            loadPath(currentPathId);
-        }
-
-        function submitOverrideRepeatCountAndResponseCode(type, pathId, methodId, ordinal) {
-            var repeatNumberValue = $("#setRepeatNumber").val();
-            var responseCodeValue = $("#setResponseCode").val();
-
-            $.ajax({
-                type:"POST",
-                url: '<c:url value="/api/path/"/>' + pathId + '/' + methodId,
-                data: {
-                    repeatNumber: repeatNumberValue,
-                    responseCode: responseCodeValue,
-                    ordinal: ordinal,
-                    clientUUID: clientUUID
-                },
-                async: false,
-                success: function(){
-                    populateEnabledResponseOverrides();
-                    populateEnabledRequestOverrides();
-                }
-            });
-        }
-
-        function submitEndPointArgs(type, pathId, methodId, ordinal, numArgs) {
-            var args = new Array();
-            for (var x = 0; x < numArgs; x++) {
-                var selector = "#" + type + "_args_" + x;
-                var value = $(selector).val();
-                args[x] = value;
-            }
-
             var formData = new FormData();
             formData.append("ordinal", ordinal);
             formData.append("clientUUID", clientUUID);
-            for (var i = 0; i < args.length; i++) {
-                formData.append('arguments[]', args[i]);
+            for (var i = 0; i < numArgs; i++) {
+                formData.append('arguments[]', $("#" + type + "_args_" + i).val());
             }
 
             $.ajax({
@@ -1816,9 +1781,23 @@
                 cache: false,
                 processData: false,
                 contentType: false,
-                async: false,
-                success: function(){
+                success: function() {
+                    var repeatNumberValue = $("#setRepeatNumber").val();
+                    var responseCodeValue = $("#setResponseCode").val();
 
+                    $.ajax({
+                        type:"POST",
+                        url: '<c:url value="/api/path/"/>' + pathId + '/' + methodId,
+                        data: {
+                            repeatNumber: repeatNumberValue,
+                            responseCode: responseCodeValue,
+                            ordinal: ordinal,
+                            clientUUID: clientUUID
+                        },
+                        success: function() {
+                            loadPath(currentPathId);
+                        }
+                    });
                 }
             });
         }

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -287,7 +287,7 @@
                     .attr({
                         type: "checkbox",
                         id: elementId,
-                        onchange: "overrideEnabledChanged(" + elementId + ", \"" + overrideType + "\")",
+                        onchange: "overrideEnabledChanged(event, " + "\"" + overrideType + "\")",
                         checked: cellvalue,
                         offval: "0",
                         "data-path": rowObject.pathId,
@@ -299,16 +299,17 @@
                 .html();
         }
 
-        function overrideEnabledChanged(element, overrideType) {
-            var pathId = $(element).data("path");
-            var enabled = element.checked ? 1 : 0;
+        function overrideEnabledChanged(event, overrideType) {
+            var $checkbox = $(event.target);
+            var pathId = $checkbox.data("path");
+            var enabled = $checkbox.is(":checked") ? 1 : 0;
 
             $.ajax({
                 type: "POST",
                 url: '<c:url value="/api/path/"/>' + pathId,
                 data: overrideType + 'Enabled=' + enabled + '&clientUUID=' + clientUUID,
-                rowId: $(element).data("row"),
-                isEnabled: element.checked,
+                rowId: $checkbox.data("row"),
+                isEnabled: $checkbox.is(":checked"),
                 error: function() {
                     alert("Could not properly set value");
                 },
@@ -826,6 +827,10 @@
                 height: "auto",
                 ignoreCase: true,
                 loadonce: true,
+                beforeSelectRow: function(rowid, event) {
+                    var $target = $(event.target);
+                    return !($target.is(":checkbox") || $target.is("label[for]"));
+                },
                 onSelectRow: function (id) {
                     var data = $("#packages").jqGrid('getRowData', id);
                     currentPathId = data.pathId;

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -117,6 +117,11 @@
             background-color: #696969;
         }
 
+        #tabs-1 .panel-default .panel-heading,
+        #tabs-2 .panel-default .panel-heading {
+            color: #777;
+        }
+
         #requestOverrideDetails form .form-group label,
         #responseOverrideDetails form .form-group label,
         #requestOverrideDetails form button,
@@ -1460,12 +1465,12 @@
 
         function setResponseOverridesActiveIndicator(isResponseEnabled) {
             $("#tabs-1 .panel").toggleClass("panel-default", !isResponseEnabled).toggleClass("panel-info", isResponseEnabled);
-            $("#tabs-1 .panel-title .label").toggle(!isResponseEnabled);
+            $("#tabs-1 .panel-title .override-inactive").toggle(!isResponseEnabled);
         }
 
         function setRequestOverridesActiveIndicator(isRequestEnabled) {
             $("#tabs-2 .panel").toggleClass("panel-default", !isRequestEnabled).toggleClass("panel-info", isRequestEnabled);
-            $("#tabs-2 .panel-title .label").toggle(!isRequestEnabled);
+            $("#tabs-2 .panel-title .override-inactive").toggle(!isRequestEnabled);
         }
 
         // get the next available ordinal for methodId on a specific path
@@ -2115,7 +2120,7 @@
                                         <div class="panel-heading">
                                             <h3 class="panel-title">
                                                 <span>Response Overrides</span>
-                                                <span class="label label-default label-medsmall">Inactive</span>
+                                                <span class="override-inactive" style="display: none; font-style: italic;">(inactive)</span>
                                             </h3>
                                         </div>
                                         <div class="panel-body">
@@ -2156,7 +2161,7 @@
                                         <div class="panel-heading">
                                             <h3 class="panel-title">
                                                 <span>Request Overrides</span>
-                                                <span class="label label-default label-medsmall">Inactive</span>
+                                                <span class="override-inactive" style="display: none; font-style: italic;">(inactive)</span>
                                             </h3>
                                         </div>
                                         <div class="panel-body">

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -225,8 +225,14 @@
                 return;
             }
 
-            $("#nav").find("#" + currentPathId).addClass("active");
-            loadPath(currentPathId);
+            let $currentPathPill = $("#nav").find("#" + currentPathId);
+
+            if ($currentPathPill.length) {
+                $currentPathPill.addClass("active");
+                loadPath(currentPathId);
+            } else {
+                loadPath(-1);
+            }
         }
 
         // common function for grid reload

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -1606,163 +1606,159 @@
         }
 
         // called to load the edit endpoint args
-        function populateEditOverrideArgs(pathId, methodId, ordinal, type, autofocusOnForm) {
+        function populateEditOverrideArgs(pathId, methodId, ordinal, overrideType, autofocusOnForm) {
             $.ajax({
                 type: "GET",
                 url: '<c:url value="/api/path/"/>' + pathId + '/' + methodId,
                 data: 'ordinal=' + ordinal + '&clientUUID=${clientUUID}',
                 success: function(data) {
-                    if(data.enabledEndpoint == null) {
-                        return;
-                    }
-
-                    $("#" + type + "OverrideDetails .panel-title")
-                        .text(data.enabledEndpoint.methodInformation.className + " " + data.enabledEndpoint.methodInformation.methodName);
-
-                    var $formData = $("<form>");
-                    var $formDiv = $("<div>").addClass("form-group");
-                    $.each(data.enabledEndpoint.methodInformation.methodArguments, function(i, el) {
-                        var inputId = type + "_args_" + i;
-                        var inputValue;
-                        if (data.enabledEndpoint.arguments.length > i) {
-                            inputValue = data.enabledEndpoint.arguments[i];
-                        } else if (data.enabledEndpoint.methodInformation.methodDefaultArguments[i] != null) {
-                            inputValue = data.enabledEndpoint.methodInformation.methodDefaultArguments[i];
-                        }
-
-                        if (typeof data.enabledEndpoint.methodInformation.methodArgumentNames[i] != 'undefined') {
-                            $formDiv
-                                .append($("<label>")
-                                    .attr("for", inputId)
-                                    .text(data.enabledEndpoint.methodInformation.methodArgumentNames[i]));
-                        }
-
-                        if (methodId == -1) {
-                            $formDiv
-                                .append($("<textarea>")
-                                    .attr({
-                                        id: inputId,
-                                        class: "form-control",
-                                        rows: 10
-                                    })
-                                    .val(inputValue)
-                                    .on("input", function(event) {
-                                        $(event.target)
-                                            .closest("form")
-                                            .find(":submit")
-                                            .text("Apply")
-                                            .attr("class", "btn btn-primary")
-                                            .attr("disabled", false);
-                                    }))
-                                .append($("<label>")
-                                    .attr("for", "setResponseCode")
-                                    .text("Response Code"))
-                                .append($("<input>")
-                                    .attr({
-                                        id: "setResponseCode",
-                                        min: 100,
-                                        max: 599,
-                                        default: data.enabledEndpoint.responseCode,
-                                        class: "form-control",
-                                        type: "number"
-                                    })
-                                    .val(data.enabledEndpoint.responseCode)
-                                    .on("input", function(event) {
-                                        $(event.target)
-                                            .closest("form")
-                                            .find(":submit")
-                                            .text("Apply")
-                                            .attr("class", "btn btn-primary")
-                                            .attr("disabled", false);
-                                    }));
-                        } else {
-                            $formDiv
-                                .append($("<label>")
-                                    .attr({
-                                        for: inputId,
-                                        style: "font-weight: normal; font-style: italic;"
-                                    })
-                                    .text("(" + el + ")"))
-                                .append($("<input>")
-                                    .attr({
-                                        id: inputId,
-                                        class: "form-control",
-                                        type: "text",
-                                    })
-                                    .val(inputValue)
-                                    .on("input", function(event) {
-                                        $(event.target)
-                                            .closest("form")
-                                            .find(":submit")
-                                            .text("Apply")
-                                            .attr("class", "btn btn-primary")
-                                            .attr("disabled", false);
-                                    }));
-                        }
-                    });
-
-                    $formDiv
-                        .append($("<label>")
-                            .attr("for", "setRepeatNumber")
-                            .text("Repeat Count"))
-                        .append($("<input>")
-                            .attr({
-                                id: "setRepeatNumber",
-                                type: "number",
-                                min: -1,
-                                default: data.enabledEndpoint.repeatNumber,
-                                required: true,
-                                class: "form-control"
-                            })
-                            .val(data.enabledEndpoint.repeatNumber)
-                            .on("input", function(event) {
-                                $(event.target)
-                                .closest("form")
-                                .find(":submit")
-                                .text("Apply")
-                                .attr("class", "btn btn-primary")
-                                .attr("disabled", false);
-                            }));
-
-                    $formData
-                        .append($formDiv)
-                        .append($("<button>")
-                            .addClass("btn btn-primary")
-                            .text("Apply"))
-                        .append($("<button>")
-                            .addClass("btn btn-default")
-                            .attr("type", "reset")
-                            .text("Clear"))
-                        .on("reset", function(event) {
-                            $(event.target)
-                                .find(":submit")
-                                .text("Apply")
-                                .attr("class", "btn btn-primary")
-                                .attr("disabled", false);
-
-                            $(":input", event.target)
-                                .not(':button, :submit, :reset, :hidden, [default]')
-                                .removeAttr('checked')
-                                .removeAttr('selected')
-                                .not(':checkbox, :radio, select')
-                                .val('');
-                            event.preventDefault();
-                        })
-                        .submit(function(event) {
-                            submitOverrideData(event, type, parseInt(pathId), parseInt(methodId), parseInt(ordinal), data.enabledEndpoint.methodInformation.methodArguments.length);
-                        });
-
-                    $("#" + type + "OverrideParameters").empty().append($formData).show();
-                    $("#" + type + "OverrideDetails").show();
-
-                    if (autofocusOnForm === true) {
-                        $("#" + type + "OverrideDetails form")
-                            .find("input, textarea")
-                            .first()
-                            .focus();
-                    }
+                    populateEditOverrideArgsSuccess(data, pathId, methodId, ordinal, overrideType, autofocusOnForm);
                 }
             });
+        }
+
+        function populateEditOverrideArgsSuccess(data, pathId, methodId, ordinal, overrideType, autofocusOnForm) {
+            if (data.enabledEndpoint == null) {
+                return;
+            }
+
+            $("#" + overrideType + "OverrideDetails .panel-title")
+                .text(data.enabledEndpoint.methodInformation.className + " " + data.enabledEndpoint.methodInformation.methodName);
+
+            var $formData = $("<form>");
+            var $formDiv = $("<div>").addClass("form-group");
+            $.each(data.enabledEndpoint.methodInformation.methodArguments, function(i, el) {
+                var inputId = overrideType + "_args_" + i;
+                var inputValue;
+                if (data.enabledEndpoint.arguments.length > i) {
+                    inputValue = data.enabledEndpoint.arguments[i];
+                } else if (data.enabledEndpoint.methodInformation.methodDefaultArguments[i] != null) {
+                    inputValue = data.enabledEndpoint.methodInformation.methodDefaultArguments[i];
+                }
+
+                if (typeof data.enabledEndpoint.methodInformation.methodArgumentNames[i] != 'undefined') {
+                    $formDiv
+                        .append($("<label>")
+                            .attr("for", inputId)
+                            .text(data.enabledEndpoint.methodInformation.methodArgumentNames[i]));
+                }
+
+                if (methodId == -1) {
+                    $formDiv
+                        .append($("<textarea>")
+                            .attr({
+                                id: inputId,
+                                class: "form-control",
+                                rows: 10
+                            })
+                            .val(inputValue)
+                            .on("input", function(event) {
+                                toggleFormSubmitEnabled($(event.target).closest("form"), true);
+                            }))
+                        .append($("<label>")
+                            .attr("for", "setResponseCode")
+                            .text("Response Code"))
+                        .append($("<input>")
+                            .attr({
+                                id: "setResponseCode",
+                                min: 100,
+                                max: 599,
+                                default: data.enabledEndpoint.responseCode,
+                                class: "form-control",
+                                type: "number"
+                            })
+                            .val(data.enabledEndpoint.responseCode)
+                            .on("input", function(event) {
+                                toggleFormSubmitEnabled($(event.target).closest("form"), true);
+                            }));
+                } else {
+                    $formDiv
+                        .append($("<label>")
+                            .attr({
+                                for: inputId,
+                                style: "font-weight: normal; font-style: italic;"
+                            })
+                            .text("(" + el + ")"))
+                        .append($("<input>")
+                            .attr({
+                                id: inputId,
+                                class: "form-control",
+                                type: "text",
+                            })
+                            .val(inputValue)
+                            .on("input", function(event) {
+                                toggleFormSubmitEnabled($(event.target).closest("form"), true);
+                            }));
+                }
+            });
+
+            $formDiv
+                .append($("<label>")
+                    .attr("for", "setRepeatNumber")
+                    .text("Repeat Count"))
+                .append($("<input>")
+                    .attr({
+                        id: "setRepeatNumber",
+                        type: "number",
+                        min: -1,
+                        default: data.enabledEndpoint.repeatNumber,
+                        required: true,
+                        class: "form-control"
+                    })
+                    .val(data.enabledEndpoint.repeatNumber)
+                    .on("input", function(event) {
+                        toggleFormSubmitEnabled($(event.target).closest("form"), true);
+                    }));
+
+            $formData
+                .append($formDiv)
+                .append($("<button>")
+                    .addClass("btn btn-primary")
+                    .text("Apply"))
+                .append($("<button>")
+                    .addClass("btn btn-default")
+                    .attr("type", "reset")
+                    .text("Clear"))
+                .on("reset", function(event) {
+                    toggleFormSubmitEnabled($(event.target), true);
+
+                    $(":input", event.target)
+                        .not(':button, :submit, :reset, :hidden, [default]')
+                        .removeAttr('checked')
+                        .removeAttr('selected')
+                        .not(':checkbox, :radio, select')
+                        .val('');
+
+                    event.preventDefault();
+                })
+                .submit(function(event) {
+                    submitOverrideData(event, overrideType, parseInt(pathId), parseInt(methodId), parseInt(ordinal), data.enabledEndpoint.methodInformation.methodArguments.length);
+                });
+
+            $("#" + overrideType + "OverrideParameters").empty().append($formData).show();
+            $("#" + overrideType + "OverrideDetails").show();
+
+            if (autofocusOnForm === true) {
+                $("#" + overrideType + "OverrideDetails form")
+                    .find("input, textarea")
+                    .first()
+                    .focus();
+            }
+        }
+
+        function toggleFormSubmitEnabled($formElement, isEnabled) {
+            var $submitButton = $formElement.find(":submit")
+
+            if (isEnabled) {
+                $submitButton
+                    .text("Apply")
+                    .attr("class", "btn btn-primary");
+            } else {
+                $submitButton
+                    .text("Saved!")
+                    .attr("class", "btn btn-success");
+            }
+            $submitButton.attr("disabled", !isEnabled)
         }
 
         function applyGeneralPathChanges() {
@@ -1845,11 +1841,7 @@
                             clientUUID: clientUUID
                         },
                         success: function() {
-                            $(event.target)
-                                .find(":submit")
-                                .text("Saved!")
-                                .attr("class", "btn btn-success")
-                                .attr("disabled", true);
+                            toggleFormSubmitEnabled($(event.target), false);
                         },
                         error: function(err) {
                             debugger;

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -1694,7 +1694,7 @@
                     event.preventDefault();
                 })
                 .submit(function(event) {
-                    submitOverrideData(event, overrideType, parseInt(pathId, 10), parseInt(methodId, 10), parseInt(ordinal, 10), data.enabledEndpoint.methodInformation.methodArguments.length);
+                    submitOverrideData(event, overrideType, parseInt(pathId, 10), parseInt(methodId, 10), parseInt(ordinal, 10));
                 });
 
             $("#" + overrideType + "OverrideParameters").empty().append($formData).show();
@@ -1773,52 +1773,32 @@
             });
         }
 
-        function submitOverrideData(event, overrideType, pathId, methodId, ordinal, numArgs) {
+        function submitOverrideData(event, overrideType, pathId, methodId, ordinal) {
             event.preventDefault();
-            var formData = new FormData();
-            formData.append("ordinal", ordinal);
-            formData.append("clientUUID", clientUUID);
-            for (var i = 0; i < numArgs; i++) {
-                formData.append('arguments[]', $("#" + overrideType + "_args_" + i).val());
-            }
+            var repeatNumberValue = $("#setRepeatNumber").val();
+            var responseCodeValue = $("#setResponseCode").val();
 
             $.ajax({
-                type:"POST",
+                type: "POST",
                 url: '<c:url value="/api/path/"/>' + pathId + '/' + methodId,
-                data: formData,
-                cache: false,
-                processData: false,
-                contentType: false,
+                data: {
+                    clientUUID: clientUUID,
+                    ordinal: ordinal,
+                    repeatNumber: repeatNumberValue,
+                    responseCode: responseCodeValue,
+                    'arguments[]': $("[id^=\"" + overrideType + "_args_\"]").map(function() {
+                            return $(this).val();
+                        }).get()
+                },
                 success: function() {
-                    var repeatNumberValue = $("#setRepeatNumber").val();
-                    var responseCodeValue = $("#setResponseCode").val();
-
-                    $.ajax({
-                        type:"POST",
-                        url: '<c:url value="/api/path/"/>' + pathId + '/' + methodId,
-                        data: {
-                            repeatNumber: repeatNumberValue,
-                            responseCode: responseCodeValue,
-                            ordinal: ordinal,
-                            clientUUID: clientUUID
-                        },
-                        success: function() {
-                            toggleFormSubmitEnabled($(event.target), false);
-                            // TODO: *MANUALLY* change the active overrides select
-                            if (overrideType == "response") {
-                                getEnabledResponseOverrides(refreshSelectedResponseOverride());
-                            } else {
-                                getEnabledRequestOverrides(refreshSelectedRequestOverride());
-                            }
-                        },
-                        error: function(err) {
-                            debugger;
-                            alert("We were unable to save your override. Please try again.");
-                        }
-                    });
+                    toggleFormSubmitEnabled($(event.target), false);
+                    if (overrideType == "response") {
+                        getEnabledResponseOverrides(refreshSelectedResponseOverride());
+                    } else {
+                        getEnabledRequestOverrides(refreshSelectedRequestOverride());
+                    }
                 },
                 error: function(err) {
-                    debugger;
                     alert("We were unable to save your override. Please try again.");
                 }
             });

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -832,6 +832,7 @@
                     updateDetailPills();
 
                     var $rowElement = $("tr#" + id);
+                    $rowElement.find("input[type=checkbox]").first().focus();
 
                     var docViewTop = $(window).scrollTop();
                     var docViewBottom = docViewTop + $(window).height();

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -1341,42 +1341,25 @@
         }
 
         function overrideMoveUp(type) {
-            var defer = $.Deferred();
-            defer.resolve();
-
-            $("select#" + type + "OverrideEnabled" + " option:selected").each(function(i, selected) {
-                defer = defer.pipe(function() {
-                    return overrideMoveUpRequest(selected.value);
-                });
-            });
-
-            defer.done(function() {
-                if (type == "response") {
-                    getEnabledResponseOverrides(refreshSelectedResponseOverride());
-                } else {
-                    getEnabledRequestOverrides(refreshSelectedRequestOverride());
-                }
-            });
-        }
-
-        function overrideMoveUpRequest(value) {
-            return $.ajax({
-                type: "POST",
-                url: '<c:url value="/api/path/"/>' + currentPathId,
-                data: {
-                    enabledMoveUp: value,
-                    clientUUID : clientUUID
-                }
-            });
+            return overrideMove(type, "Up");
         }
 
         function overrideMoveDown(type) {
+            return overrideMove(type, "Down");
+        }
+
+        function overrideMove(type, direction) {
             var defer = $.Deferred();
             defer.resolve();
 
-            $($("select#" + type + "OverrideEnabled" + " option:selected").get().reverse()).each(function(i, selected) {
+            var $options = $("select#" + type + "OverrideEnabled" + " option:selected");
+            if (direction == "Down") {
+                $options = $($options.get().reverse());
+            }
+
+            $options.each(function(i, selected) {
                 defer = defer.pipe(function() {
-                    return overrideMoveDownRequest(selected.value);
+                    return overrideMoveRequest(selected.value, direction);
                 });
             });
 
@@ -1389,14 +1372,14 @@
             });
         }
 
-        function overrideMoveDownRequest(value) {
+        function overrideMoveRequest(value, direction) {
+            var data = { clientUUID: clientUUID };
+            data["enabledMove" + direction] = value;
+
             return $.ajax({
                 type: "POST",
                 url: '<c:url value="/api/path/"/>' + currentPathId,
-                data: {
-                    enabledMoveDown: value,
-                    clientUUID: clientUUID
-                }
+                data: data
             });
         }
 

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -1645,7 +1645,15 @@
                                         class: "form-control",
                                         rows: 10
                                     })
-                                    .val(inputValue))
+                                    .val(inputValue)
+                                    .on("input", function(event) {
+                                        $(event.target)
+                                            .closest("form")
+                                            .find(":submit")
+                                            .text("Apply")
+                                            .attr("class", "btn btn-primary")
+                                            .attr("disabled", false);
+                                    }))
                                 .append($("<label>")
                                     .attr("for", "setResponseCode")
                                     .text("Response Code"))
@@ -1654,10 +1662,19 @@
                                         id: "setResponseCode",
                                         min: 100,
                                         max: 599,
+                                        default: data.enabledEndpoint.responseCode,
                                         class: "form-control",
                                         type: "number"
                                     })
-                                    .val(data.enabledEndpoint.responseCode));
+                                    .val(data.enabledEndpoint.responseCode)
+                                    .on("input", function(event) {
+                                        $(event.target)
+                                            .closest("form")
+                                            .find(":submit")
+                                            .text("Apply")
+                                            .attr("class", "btn btn-primary")
+                                            .attr("disabled", false);
+                                    }));
                         } else {
                             $formDiv
                                 .append($("<label>")
@@ -1672,7 +1689,15 @@
                                         class: "form-control",
                                         type: "text",
                                     })
-                                    .val(inputValue));
+                                    .val(inputValue)
+                                    .on("input", function(event) {
+                                        $(event.target)
+                                            .closest("form")
+                                            .find(":submit")
+                                            .text("Apply")
+                                            .attr("class", "btn btn-primary")
+                                            .attr("disabled", false);
+                                    }));
                         }
                     });
 
@@ -1685,9 +1710,19 @@
                                 id: "setRepeatNumber",
                                 type: "number",
                                 min: -1,
+                                default: data.enabledEndpoint.repeatNumber,
+                                required: true,
                                 class: "form-control"
                             })
-                            .val(data.enabledEndpoint.repeatNumber));
+                            .val(data.enabledEndpoint.repeatNumber)
+                            .on("input", function(event) {
+                                $(event.target)
+                                .closest("form")
+                                .find(":submit")
+                                .text("Apply")
+                                .attr("class", "btn btn-primary")
+                                .attr("disabled", false);
+                            }));
 
                     $formData
                         .append($formDiv)
@@ -1698,9 +1733,23 @@
                             .addClass("btn btn-default")
                             .attr("type", "reset")
                             .text("Clear"))
-                        .submit(function(e) {
-                            e.preventDefault();
-                            submitOverrideData(type, parseInt(pathId), parseInt(methodId), parseInt(ordinal), data.enabledEndpoint.methodInformation.methodArguments.length);
+                        .on("reset", function(event) {
+                            $(event.target)
+                                .find(":submit")
+                                .text("Apply")
+                                .attr("class", "btn btn-primary")
+                                .attr("disabled", false);
+
+                            $(":input", event.target)
+                                .not(':button, :submit, :reset, :hidden, [default]')
+                                .removeAttr('checked')
+                                .removeAttr('selected')
+                                .not(':checkbox, :radio, select')
+                                .val('');
+                            event.preventDefault();
+                        })
+                        .submit(function(event) {
+                            submitOverrideData(event, type, parseInt(pathId), parseInt(methodId), parseInt(ordinal), data.enabledEndpoint.methodInformation.methodArguments.length);
                         });
 
                     $("#" + type + "OverrideParameters").empty().append($formData).show();
@@ -1766,7 +1815,8 @@
             });
         }
 
-        function submitOverrideData(type, pathId, methodId, ordinal, numArgs) {
+        function submitOverrideData(event, type, pathId, methodId, ordinal, numArgs) {
+            event.preventDefault();
             var formData = new FormData();
             formData.append("ordinal", ordinal);
             formData.append("clientUUID", clientUUID);
@@ -1795,9 +1845,21 @@
                             clientUUID: clientUUID
                         },
                         success: function() {
-                            loadPath(currentPathId);
+                            $(event.target)
+                                .find(":submit")
+                                .text("Saved!")
+                                .attr("class", "btn btn-success")
+                                .attr("disabled", true);
+                        },
+                        error: function(err) {
+                            debugger;
+                            alert("We were unable to save your override. Please try again.");
                         }
                     });
+                },
+                error: function(err) {
+                    debugger;
+                    alert("We were unable to save your override. Please try again.");
                 }
             });
         }

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -308,6 +308,7 @@
                 type: "POST",
                 url: '<c:url value="/api/path/"/>' + pathId,
                 data: overrideType + 'Enabled=' + enabled + '&clientUUID=' + clientUUID,
+                originalTargetId: $checkbox.attr("id"),
                 rowId: $checkbox.data("row"),
                 isEnabled: $checkbox.is(":checked"),
                 error: function() {
@@ -318,6 +319,8 @@
                     rowData[overrideType + "Enabled"] = this.isEnabled;
                     $("#packages").setRowData(this.rowId, rowData);
                     $("#packages").setSelection(this.rowId, true);
+                    // maintain focus on checkbox
+                    $("#" + this.originalTargetId).focus();
                 }
             });
         }
@@ -831,13 +834,16 @@
                     var $target = $(event.target);
                     return !($target.is(":checkbox") || $target.is("label[for]"));
                 },
-                onSelectRow: function (id) {
+                onSelectRow: function(id) {
                     var data = $("#packages").jqGrid('getRowData', id);
                     currentPathId = data.pathId;
                     updateDetailPills();
 
                     var $rowElement = $("tr#" + id);
-                    $rowElement.find("input[type=checkbox]").first().focus();
+
+                    if(!$rowElement.find(":checkbox").is(":focus").length) {
+                        $rowElement.find(":checkbox").first().focus();
+                    }
 
                     var docViewTop = $(window).scrollTop();
                     var docViewBottom = docViewTop + $(window).height();

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -277,15 +277,17 @@
             $(gridId).setGridParam({datatype:'json', page:1}).trigger("reloadGrid");
         }
 
-        function responseEnabledFormatter(cellvalue, options, rowObject) {
-            var elementId = "response_enabled_" + rowObject.pathId;
+        function overrideEnabledFormatter(cellvalue, options, rowObject) {
+            var overrideType = options.colModel.name === "requestEnabled" ? "request" : "response";
+
+            var elementId = overrideType + "_enabled_" + rowObject.pathId;
 
             return $("<div>")
                 .append($("<input>")
                     .attr({
                         type: "checkbox",
                         id: elementId,
-                        onchange: "responseEnabledChanged(" + elementId + ")",
+                        onchange: "overrideEnabledChanged(" + elementId + ", \"" + overrideType + "\")",
                         checked: cellvalue,
                         offval: "0",
                         "data-path": rowObject.pathId,
@@ -297,14 +299,14 @@
                 .html();
         }
 
-        function responseEnabledChanged(element) {
+        function overrideEnabledChanged(element, overrideType) {
             var pathId = $(element).data("path");
             var enabled = element.checked ? 1 : 0;
 
             $.ajax({
                 type: "POST",
                 url: '<c:url value="/api/path/"/>' + pathId,
-                data: 'responseEnabled=' + enabled + '&clientUUID=' + clientUUID,
+                data: overrideType + 'Enabled=' + enabled + '&clientUUID=' + clientUUID,
                 rowId: $(element).data("row"),
                 isEnabled: element.checked,
                 error: function() {
@@ -312,48 +314,7 @@
                 },
                 success: function() {
                     var rowData = $("#packages").getLocalRow(this.rowId);
-                    rowData.responseEnabled = this.isEnabled;
-                    $("#packages").setRowData(this.rowId, rowData);
-                    $("#packages").setSelection(this.rowId, true);
-                }
-            });
-        }
-
-        function requestEnabledFormatter(cellvalue, options, rowObject) {
-            var elementId = "request_enabled_" + rowObject.pathId;
-            return $("<div>")
-                .append($("<input>")
-                    .attr({
-                        type: "checkbox",
-                        id: elementId,
-                        onchange: "requestEnabledChanged(" + elementId + ")",
-                        checked: cellvalue,
-                        offval: "0",
-                        "data-path": rowObject.pathId,
-                        "data-row": options.rowId
-                    })
-                    .addClass("mousetrap")
-                    .val(cellvalue ? "1" : "0"))
-                .append($("<label>").attr("for", elementId))
-                .html();
-        }
-
-        function requestEnabledChanged(element) {
-            var pathId = $(element).data("path");
-            var enabled = element.checked ? 1 : 0;
-
-            $.ajax({
-                type: "POST",
-                url: '<c:url value="/api/path/"/>' + pathId,
-                data: 'requestEnabled=' + enabled + '&clientUUID=' + clientUUID,
-                rowId: $(element).data("row"),
-                isEnabled: element.checked,
-                error: function() {
-                    alert("Could not properly set value");
-                },
-                success: function() {
-                    var rowData = $("#packages").getLocalRow(this.rowId);
-                    rowData.requestEnabled = this.isEnabled;
+                    rowData[overrideType + "Enabled"] = this.isEnabled;
                     $("#packages").setRowData(this.rowId, rowData);
                     $("#packages").setSelection(this.rowId, true);
                 }
@@ -831,7 +792,7 @@
                         width: 50,
                         align: 'center',
                         editable: false,
-                        formatter: responseEnabledFormatter,
+                        formatter: overrideEnabledFormatter,
                         formatoptions: {disabled: false},
                         search: true,
                         searchoptions: {
@@ -844,7 +805,7 @@
                         width: 50,
                         align: 'center',
                         editable: false,
-                        formatter: requestEnabledFormatter,
+                        formatter: overrideEnabledFormatter,
                         formatoptions: {disabled: false},
                         search: true,
                         searchoptions: {

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -47,23 +47,49 @@
             font-size: 1.333333333em;
         }
 
-        #packages td input[type=checkbox]:focus  + label,
-        #packages td input[type=checkbox]:active + label {
-            outline: 2px solid blue;
-        }
-
-        #packages td input[type=checkbox] + label:before {
-            content: "✗";
+        #packages td input[type=checkbox] + label {
             color: #aaa;
         }
 
-        #packages td input[type=checkbox]:checked + label {
-            background-color: green;
+        #packages td input[type=checkbox]:active + label {
+            background-color: #bbddee;
         }
 
+        #packages td input[type=checkbox]:active:checked + label:before,
+        #packages td input[type=checkbox] + label:before {
+            content: "✗";
+        }
+
+        #packages td input[type=checkbox]:checked + label {
+            background-color: #3399cc;
+            color: white;
+        }
+
+        #packages td input[type=checkbox]:active:checked + label {
+            background-color: #cce6f2;
+        }
+
+        #packages td input[type=checkbox]:active + label:before,
         #packages td input[type=checkbox]:checked + label:before {
             content: "✔";
-            color: white;
+        }
+
+        #packages td input[type=checkbox]:focus  + label {
+            /* Permalink - use to edit and share this gradient: http://colorzilla.com/gradient-editor/#0a0e0a+0,0a0809+100&0+0,0+93,1+94,1+100 */
+            background: linear-gradient(135deg, rgba(0,0,0,0) 0%,rgba(0,0,0,0) 88%,black 90%,black 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+        }
+
+        #packages td input[type=checkbox]:focus:active  + label {
+            background: linear-gradient(135deg, #bbddee 0%,#bbddee 88%,black 90%,black 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+        }
+
+        #packages td input[type=checkbox]:checked:focus  + label {
+            /* gradient with blue background */
+            background: linear-gradient(135deg, #3399cc 0%,#3399cc 88%,black 90%,black 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
+        }
+
+        #packages td input[type=checkbox]:checked:focus:active  + label {
+            background: linear-gradient(135deg, #cce6f2 0%,#cce6f2 88%,black 90%,black 100%); /* W3C, IE10+, FF16+, Chrome26+, Opera12+, Safari7+ */
         }
 
         #nav > li > a {

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -191,10 +191,11 @@
 
         // Keeps the list of pills updated
         function updateDetailPills() {
-            var ids = $("#packages").jqGrid('getRowData');
+            var rowData = $("#packages").jqGrid('getGridParam', 'data'); // all rows and data
+            var rowIds = $("#packages").jqGrid('getDataIDs'); // visible rows IDs
 
             $(".nav-pills > li").remove();
-            if (ids.length === 0) {
+            if (rowIds.length === 0) {
                 loadPath(-1);
                 return;
             }
@@ -202,19 +203,18 @@
             // TODO: Use foreach?
             var selectedRow = $("#packages").jqGrid("getGridParam", "selrow");
             var pillsShown = false;
-            $.each(ids, function(index, el) {
-                // TODO: Need cleaner way to do this
-                if (el.requestEnabled.indexOf("checked") + el.responseEnabled.indexOf("checked") > -2
-                    || index + 1 == selectedRow) {
+            $.each(rowIds, function(_index_, rowId) {
+                var rowInfo = rowData[parseInt(rowId) - 1];
+                if (rowInfo.requestEnabled || rowInfo.responseEnabled || rowId == selectedRow) {
                     $("#nav").append($("<li>")
-                        .attr("id", el.pathId)
+                        .attr("id", rowInfo.pathId)
                         .append($("<a>")
                             .attr({
-                                "href": "#tab" + el.pathId,
+                                "href": "#tab" + rowInfo.pathId,
                                 "data-toggle": "tab"})
-                            .text(el.pathName)
+                            .text(rowInfo.pathName)
                             .click(function() {
-                                $("#packages").setSelection(index + 1, true);
+                                $("#packages").setSelection(rowId, true);
                             })));
 
                     pillsShown = true;

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -831,9 +831,25 @@
                 ignoreCase: true,
                 loadonce: true,
                 onSelectRow: function (id) {
-                    var data = $("#packages").jqGrid('getRowData',id);
+                    var data = $("#packages").jqGrid('getRowData', id);
                     currentPathId = data.pathId;
                     updateDetailPills();
+
+                    var $rowElement = $("tr#" + id);
+
+                    var docViewTop = $(window).scrollTop();
+                    var docViewBottom = docViewTop + $(window).height();
+
+                    var elemTop = $rowElement.offset().top;
+                    var elemBottom = elemTop + $rowElement.height();
+
+                    if ((elemBottom <= docViewBottom) && (elemTop >= docViewTop)) {
+                        return;
+                    }
+
+                    $([document.documentElement, document.body]).animate({
+                        scrollTop: $rowElement.offset().top - $(window).height() / 2
+                    }, 100);
                 },
                 loadComplete: function() {
                     updateDetailPills();

--- a/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/edit.jsp
@@ -1243,7 +1243,7 @@
 
         function loadPath(pathId) {
             if(pathId < 0) {
-                $("#editDiv").hide();
+                $("#tabs").hide();
                 return;
             }
 
@@ -1253,7 +1253,7 @@
                 data: 'clientUUID=${clientUUID}',
                 success: function(data) {
                     // populate Configuration values
-                    $("#editDiv").show();
+                    $("#tabs").show();
                     $("#pathName").attr("value", data.pathName);
                     $("#pathValue").attr("value", data.path);
                     $("#contentType").attr("value", data.contentType);
@@ -1638,20 +1638,19 @@
                                         class: "form-control",
                                         rows: 10
                                     })
-                                    .text(inputValue))
+                                    .val(inputValue))
                                 .append($("<label>")
                                     .attr("for", "setResponseCode")
                                     .text("Response Code"))
-                                .append($("<dd>")
-                                    .append($("<input>")
-                                        .attr({
-                                            id: "setResponseCode",
-                                            min: 100,
-                                            max: 599,
-                                            class: "form-control",
-                                            type: "number"
-                                        })
-                                        .val(data.enabledEndpoint.responseCode)));
+                                .append($("<input>")
+                                    .attr({
+                                        id: "setResponseCode",
+                                        min: 100,
+                                        max: 599,
+                                        class: "form-control",
+                                        type: "number"
+                                    })
+                                    .val(data.enabledEndpoint.responseCode));
                         } else {
                             $formDiv
                                 .append($("<label>")
@@ -2039,7 +2038,7 @@
             </div>
 
             <div id="details" class="col-xs-7">
-                <div id="editDiv" style="display: none;">
+                <div id="editDiv">
                     <div style="position: relative;">
                         <ul class="nav nav-pills" id="nav">
                         </ul>

--- a/proxyui/src/main/webapp/WEB-INF/views/history.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/history.jsp
@@ -738,7 +738,7 @@
         Mousetrap.bind('c c', function() { // cURL command
             $("#copyCURLCommand:visible").click();
         });
-        Mousetrap.bind('alt+del', clearHistory);
+        Mousetrap.bind(['alt+del', 'alt+backspace'], clearHistory);
 
         $("#historylist").jqGrid({
             url : '<c:url value="/api/history/${profile_id}"/>?clientUUID=${clientUUID}',

--- a/proxyui/src/main/webapp/WEB-INF/views/history.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/history.jsp
@@ -345,10 +345,8 @@
       return cellvalue;
     }
 
-    function requestParamsFormatter(cellvalue) {
-        cellvalue = decodeURIComponent(cellvalue);
-        if (cellvalue.length < 253) { return cellvalue; }
-        return cellvalue.slice(0, 250) + " ...";
+    function requestParamsFormatter(cellvalue, options) {
+        return "<div style='overflow: scroll;'>" + cellvalue + "</div>";
     }
 
     var invalidRows = []
@@ -789,7 +787,10 @@
                     editable : false,
                     sortable: false,
                     classes: 'break-all preformatted',
-                    formatter: requestParamsFormatter
+                    formatter: requestParamsFormatter,
+                    cellattr: function () {
+                        return 'style="word-break: inherit;"'
+                    }
                 }, {
                     name : 'responseCode',
                     index : 'responseCode',

--- a/proxyui/src/main/webapp/WEB-INF/views/history.jsp
+++ b/proxyui/src/main/webapp/WEB-INF/views/history.jsp
@@ -253,7 +253,7 @@
     }
 
     function saveGridOptions(e) {
-        var historyGridRows = parseInt($("#numberOfRows").val());
+        var historyGridRows = parseInt($("#numberOfRows").val(), 10);
         if (!isNaN(historyGridRows)) {
             $.cookie("historyGridRows", historyGridRows, {
                 expires: 10000,

--- a/proxyui/src/main/webapp/resources/css/odo.css
+++ b/proxyui/src/main/webapp/resources/css/odo.css
@@ -15,6 +15,12 @@ body {
     vertical-align: middle;
 }
 
+.label-medsmall
+{
+    font-size: 70%;
+    vertical-align: middle;
+}
+
 .reorderbox
 {
     -webkit-box-sizing: content-box;

--- a/proxyui/src/main/webapp/resources/css/odo.css
+++ b/proxyui/src/main/webapp/resources/css/odo.css
@@ -15,12 +15,6 @@ body {
     vertical-align: middle;
 }
 
-.label-medsmall
-{
-    font-size: 70%;
-    vertical-align: middle;
-}
-
 .reorderbox
 {
     -webkit-box-sizing: content-box;


### PR DESCRIPTION
This PR brings further improvements to the Edit Overrides page on top of #170.

You might have an easier time viewing this PR without white space changes, of which there are quite a few: https://github.com/groupon/odo/pull/172/files?w=1.

Improved UI
----
* More user friendly and intuitive, allowing the user to click anywhere in the request/response cells of the paths table to toggle an override.
* Keyboard navigation for navigating through override paths and enabling/disabling request and response overrides (Up/Down/Left/Right when you are focused on a checkbox in the paths list)
* Keep selected row and active overrides navigation aligned, and within the window viewport (you can use Alt Left/Right to navigate through the active overrides; this is an existing feature since last version)
* Order of active overrides navigation is now consistent with the displayed paths, including when filtered and/or sorted g-liu#26
* Override editor provides indications of whether the selected override is active or not
* "Clear" button behavior improved on single override editor - will retain default values and clear all else
* Display visual confirmation when override is saved

Behind the scenes
----
* **UTF-8 support for overrides! Hooray!** g-liu#12
* Code cleanup as usual
* Improve performance of showing the active override navigation
* Bugfix: Scrolling down and enabling an override for the first time did not show the Edit Overrides panel on the right hand side, until the user scrolled again
* Bugfix: On history page, Alt+delete would clear history but Alt+Backspace did not
* Bugfix: When a path is inactive and we add the first request or response override for the first time, enable the path and focus on the edit override div
* Alt+Delete will also clear history now. Useful on macbooks where there is no "delete" key strictly speaking
* Move up/down, and remove, of path overrides is much more reliable now. However it is still buggy due to the server limitation of only allowing an operation to affect a single override at a time. We chain the move/delete requests now instead of the old everything-goes, race-condition- prone method of firing the requests simultaneously.

Screenshots
----
New checkbox styles. Click anywhere within the box to toggle.
![image](https://user-images.githubusercontent.com/3281451/54166723-bbfd6200-4423-11e9-97d3-4f0373a64c56.png)

Inactive override indication
![image](https://user-images.githubusercontent.com/3281451/54166781-fc5ce000-4423-11e9-8079-e28e2e00f27a.png)

Override saved confirmation
![image](https://user-images.githubusercontent.com/3281451/54166789-07177500-4424-11e9-8c28-ec430cb209e1.png)

UTF-8 support
![image](https://user-images.githubusercontent.com/3281451/54319359-95b3ff80-45a6-11e9-9ee3-c437359e48ca.png)
