### PR TITLE
Update pom.xml

### DIFF
--- a/proxylib/pom.xml
+++ b/proxylib/pom.xml
@@ -89,6 +89,13 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.3.1</version>
+      <scope>compile</scope>
+    </dependency>
+      
     <!-- Logging -->
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -135,12 +142,6 @@
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
       <version>1.3.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.httpcomponents</groupId>
-      <artifactId>httpclient</artifactId>
-      <version>4.3.1</version>
-      <scope>compile</scope>
     </dependency>
 
     <!-- Dependencies for Bean Scripting Framework/Groovy -->


### PR DESCRIPTION
Fix dependency conflict issue #173 by reversing the declaration order of **_httpclient_** and **_jcl-over-slf4j_** in pom file, which transitively introduce the conclicting libraries.
This fix will not affect other libraries or class, except the above duplicate class.
